### PR TITLE
analytics.page documentation / library mismatch

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,62 @@ var version = require('../package.json').version;
 global.setImmediate = global.setImmediate || process.nextTick.bind(process);
 
 /**
+ * Internal helper functions for creating `pure` functions
+ */
+_clone = function(source) {
+  var dest = {};
+  for (key in source) {
+    dest[key] = source[key];
+  }
+  return dest;
+}
+
+_defaults = function(source, defaults) {
+  source = _clone(source);
+  for (key in defaults) {
+    if (source[key] !== null){
+      source[key] = defaults[key];
+    }
+  }
+  return source;
+}
+
+/**
+ * Adds `userAgent` and `ip` to `message.context` based on the passed in
+ * `request`. For `page` events, the `path`, `referrer` and `url` are also
+ * included.
+ *
+ * @param {Object} message
+ * @param {Object} request
+ * @param {Boolean} page (optional)
+ */
+
+addContext = function(message, request, page){
+  if (typeof(request) === 'undefined' || request === null){return message;}
+
+  if (page) {
+    var pageProperties = {
+      path: request.path,
+      referrer: request.headers && request.headers['referer'],
+      url: request.originalUrl
+    };
+    message.properties = _defaults(message.properties, pageProperties);
+  }
+  else {
+    message = _clone(message);
+  }
+
+  var contextProperties = {
+    userAgent: request.headers && request.headers['user-agent'],
+    ip: request.headers && request.headers['x-forwarded-for'] ||
+      request.connection && request.connection.remoteAddress
+  };
+  message.context = _defaults(message.context, contextProperties);
+
+  return message;
+}
+
+/**
  * Expose an `Analytics` client.
  */
 
@@ -42,11 +98,16 @@ function Analytics(writeKey, options){
  * Send an identify `message`.
  *
  * @param {Object} message
+ * @param {Object} request (optional)
  * @param {Function} fn (optional)
  * @return {Analytics}
  */
 
-Analytics.prototype.identify = function(message, fn){
+Analytics.prototype.identify = function(message, request, fn){
+  if (arguments.length < 3 && typeof request === 'function') {
+    fn = req; req = undefined;
+  }
+  message = addContext(message, request);
   validate(message);
   assert(message.anonymousId || message.userId, 'You must pass either an "anonymousId" or a "userId".');
   this.enqueue('identify', message, fn);
@@ -57,11 +118,16 @@ Analytics.prototype.identify = function(message, fn){
  * Send a group `message`.
  *
  * @param {Object} message
+ * @param {Object} request (optional)
  * @param {Function} fn (optional)
  * @return {Analytics}
  */
 
-Analytics.prototype.group = function(message, fn){
+Analytics.prototype.group = function(message, request, fn){
+  if (arguments.length < 3 && typeof request === 'function') {
+    fn = request; request = undefined;
+  }
+  message = addContext(message, request);
   validate(message);
   assert(message.anonymousId || message.userId, 'You must pass either an "anonymousId" or a "userId".');
   assert(message.groupId, 'You must pass a "groupId".');
@@ -73,11 +139,16 @@ Analytics.prototype.group = function(message, fn){
  * Send a track `message`.
  *
  * @param {Object} message
+ * @param {Object} request (optional)
  * @param {Function} fn (optional)
  * @return {Analytics}
  */
 
-Analytics.prototype.track = function(message, fn){
+Analytics.prototype.track = function(message, request, fn){
+  if (arguments.length < 3 && typeof request === 'function') {
+    fn = request; request = undefined;
+  }
+  message = addContext(message, request);
   validate(message);
   assert(message.anonymousId || message.userId, 'You must pass either an "anonymousId" or a "userId".');
   assert(message.event, 'You must pass an "event".');
@@ -89,11 +160,16 @@ Analytics.prototype.track = function(message, fn){
  * Send a page `message`.
  *
  * @param {Object} message
+ * @param {Object} request (optional)
  * @param {Function} fn (optional)
  * @return {Analytics}
  */
 
-Analytics.prototype.page = function(message, fn){
+Analytics.prototype.page = function(message, request, fn){
+  if (arguments.length < 3 && typeof request === 'function') {
+    fn = request; request = undefined;
+  }
+  message = addContext(message, request, true);
   validate(message);
   assert(message.anonymousId || message.userId, 'You must pass either an "anonymousId" or a "userId".');
   this.enqueue('page', message, fn);
@@ -104,11 +180,16 @@ Analytics.prototype.page = function(message, fn){
  * Send an alias `message`.
  *
  * @param {Object} message
+ * @param {Object} request (optional)
  * @param {Function} fn (optional)
  * @return {Analytics}
  */
 
-Analytics.prototype.alias = function(message, fn){
+Analytics.prototype.alias = function(message, request, fn){
+  if (arguments.length < 3 && typeof request === 'function') {
+    fn = request; request = undefined;
+  }
+  message = addContext(message, request);
   validate(message);
   assert(message.userId, 'You must pass a "userId".');
   assert(message.previousId, 'You must pass a "previousId".');


### PR DESCRIPTION
From https://segment.io/docs/libraries/node/: 

> A few properties are automatically added to each .page() call. For example, if you call:
>
> analytics.page('Pricing');
> We will translate that to the following without any extra work from you:
>
> analytics.track('Pricing', {
>   title: 'Segment.io Pricing',
>   url: 'https://segment.io/pricing',
>   path: '/pricing',
>   referrer: 'https://segment.io'
> });

I was sceptic (but hopeful) when I saw .page() promised to do all this without being passed a request object or headers. It looks like all the documentation for page is from the browser library.

Having said that, it would be very handy for the library to extract these from a headers argument though, any plans for adding this? I'm having to write this for a wrapper around analytics-node anyway, so won't mind creating a PR to integrate it into the library.