### PR TITLE
Update superagent@0.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "component-type": "~1.0.0",
     "join-component": "~1.0.0",
     "lodash": "~2.4.1",
-    "superagent": "~0.16.0",
+    "superagent": "~0.21.0",
     "superagent-proxy": "~0.3.1",
     "debug": "~1.0.4",
     "uid": "0.0.2"


### PR DESCRIPTION
The previous dependency version (`superagent@0.16.0`) uses a vulnerable version of `qs` which has been patched since version `>= 1.x`, included in `superagent >= 0.19`.