### PR TITLE
Adds a "license" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,6 @@
   },
   "scripts": {
     "test": "make test"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
This allows our license scraper to automatically pick up the license on the
package. I referred to https://docs.npmjs.com/files/package.json#license
for the syntax.