### PR TITLE
use documented endpoint: /v1/batch -> /v1/import

### DIFF
--- a/analytics-node.js
+++ b/analytics-node.js
@@ -148,7 +148,7 @@ Analytics.prototype.flush = function(fn){
   debug('flush: %o', data);
 
   var req = request
-    .post(this.host + '/v1/batch');
+    .post(this.host + '/v1/import');
 
   if (this.proxy) {
     req = req.proxy(this.proxy);

--- a/lib/index.js
+++ b/lib/index.js
@@ -146,7 +146,7 @@ Analytics.prototype.flush = function(fn){
   debug('flush: %o', data);
 
   var req = request
-    .post(this.host + '/v1/batch');
+    .post(this.host + '/v1/import');
 
   if (this.proxy) {
     req = req.proxy(this.proxy);

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ describe('Analytics', function(){
       },
       function(cb){
         server.app
-          .post('/v1/batch', server.fixture)
+          .post('/v1/import', server.fixture)
           .listen(server.ports.source, cb);
       }
     ], done);


### PR DESCRIPTION
[Docs for HTTP interface](https://segment.com/docs/libraries/http/#import) reference `/v1/import`, but not `/v1/batch`.

noticed when comparing against segmentio/analytics-java, which [uses it](https://github.com/segmentio/analytics-java/blob/175396/src/main/java/com/github/segmentio/request/BlockingRequester.java#L92-L93).

Looks like the majority of segmentio libraries [use the import route](https://github.com/search?q=user%3Asegmentio+%22%2Fv1%2Fimport%22&ref=searchresults&type=Code&utf8=%E2%9C%93) (ruby, php, .net, android, java, iOS), although a few [use the batch route](https://github.com/search?q=user%3Asegmentio+%22%2Fv1%2Fbatch%22&ref=searchresults&type=Code&utf8=%E2%9C%93) (python, node, go)

It seems like the change might have accidentally happened in fead055 (as the endpoint [here](https://github.com/segmentio/analytics-node/commit/fead055#diff-5391bde944956870128be1136e7bc176L24) was different in [equivalent place below](https://github.com/segmentio/analytics-node/commit/fead055#diff-6d186b954a58d5bb740f73d84fe39073R144))