### PR TITLE
Corporate Proxy Support

### DIFF
--- a/analytics-node.js
+++ b/analytics-node.js
@@ -15,16 +15,16 @@ var version = require('../package.json').version;
 var extend = require('lodash').extend;
 
 global.setImmediate = global.setImmediate || process.nextTick.bind(process);
-//
+
 /** 
  * Use globa-tunnel to provide proxy support.
  * The http_proxy environment variable will be used if the first parameter to globalTunnel.initialize is null.
 */
 globalTunnel.initialize();
+
 /**
  * Expose an `Analytics` client.
  */
-
 module.exports = Analytics;
 
 /**

--- a/analytics-node.js
+++ b/analytics-node.js
@@ -1,6 +1,7 @@
 !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.Analytics=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 (function (process,global){
 var assert = require('assert');
+var globalTunnel = require('global-tunnel');
 var clone = require('clone');
 var debug = require('debug')('analytics-node');
 var noop = function(){};
@@ -14,7 +15,12 @@ var version = require('../package.json').version;
 var extend = require('lodash').extend;
 
 global.setImmediate = global.setImmediate || process.nextTick.bind(process);
-
+//
+/** 
+ * Use globa-tunnel to provide proxy support.
+ * The http_proxy environment variable will be used if the first parameter to globalTunnel.initialize is null.
+*/
+globalTunnel.initialize();
 /**
  * Expose an `Analytics` client.
  */

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "superagent-proxy": "~0.3.1",
     "superagent-retry": "~0.4.0",
     "debug": "~1.0.4",
-    "uid": "0.0.2"
+    "uid": "0.0.2",
+    "global-tunnel": "~1.2.0"
   },
   "devDependencies": {
     "async": "~0.9.0",


### PR DESCRIPTION
I included the module global-tunnel to provide proxy support using the variable HTTP_PROXY.

Use globa-tunnel to provide proxy support.
The http_proxy environment variable will be used if the first parameter to globalTunnel.initialize is null.