### PR TITLE
Reset flushing timer only during flush

### DIFF
--- a/analytics-node.js
+++ b/analytics-node.js
@@ -129,7 +129,10 @@ Analytics.prototype.alias = function(message, fn){
 
 Analytics.prototype.flush = function(fn){
   fn = fn || noop;
-  if (this.timer) clearTimeout(this.timer);
+  if (this.timer) {
+    clearTimeout(this.timer);
+    this.timer = null;
+  }
   if (!this.queue.length) return setImmediate(fn);
 
   var items = this.queue.splice(0, this.flushAt);

--- a/analytics-node.js
+++ b/analytics-node.js
@@ -129,6 +129,7 @@ Analytics.prototype.alias = function(message, fn){
 
 Analytics.prototype.flush = function(fn){
   fn = fn || noop;
+  if (this.timer) clearTimeout(this.timer);
   if (!this.queue.length) return setImmediate(fn);
 
   var items = this.queue.splice(0, this.flushAt);
@@ -181,8 +182,7 @@ Analytics.prototype.enqueue = function(type, message, fn){
   });
 
   if (this.queue.length >= this.flushAt) this.flush();
-  if (this.timer) clearTimeout(this.timer);
-  if (this.flushAfter) this.timer = setTimeout(this.flush.bind(this), this.flushAfter);
+  if (this.flushAfter && !this.timer)  this.timer = setTimeout(this.flush.bind(this), this.flushAfter);
 };
 
 /**
@@ -2389,7 +2389,7 @@ function clone(parent, circular, depth, prototype) {
       if (proto) {
         attrs = Object.getOwnPropertyDescriptor(proto, i);
       }
-      
+
       if (attrs && attrs.set == null) {
         continue;
       }
@@ -10114,7 +10114,7 @@ process.umask = function() { return 0; };
  * TODO: combatible error handling?
  */
 
-module.exports = function(arr, fn, initial){  
+module.exports = function(arr, fn, initial){
   var idx = 0;
   var len = arr.length;
   var curr = arguments.length == 3
@@ -10124,7 +10124,7 @@ module.exports = function(arr, fn, initial){
   while (idx < len) {
     curr = fn.call(null, curr, arr[idx], ++idx, arr);
   }
-  
+
   return curr;
 };
 },{}],18:[function(require,module,exports){

--- a/lib/index.js
+++ b/lib/index.js
@@ -127,6 +127,7 @@ Analytics.prototype.alias = function(message, fn){
 
 Analytics.prototype.flush = function(fn){
   fn = fn || noop;
+  if (this.timer) clearTimeout(this.timer);
   if (!this.queue.length) return setImmediate(fn);
 
   var items = this.queue.splice(0, this.flushAt);
@@ -179,8 +180,7 @@ Analytics.prototype.enqueue = function(type, message, fn){
   });
 
   if (this.queue.length >= this.flushAt) this.flush();
-  if (this.timer) clearTimeout(this.timer);
-  if (this.flushAfter) this.timer = setTimeout(this.flush.bind(this), this.flushAfter);
+  if (this.flushAfter && !this.timer)  this.timer = setTimeout(this.flush.bind(this), this.flushAfter);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -127,7 +127,10 @@ Analytics.prototype.alias = function(message, fn){
 
 Analytics.prototype.flush = function(fn){
   fn = fn || noop;
-  if (this.timer) clearTimeout(this.timer);
+  if (this.timer) {
+    clearTimeout(this.timer);
+    this.timer = null;
+  }
   if (!this.queue.length) return setImmediate(fn);
 
   var items = this.queue.splice(0, this.flushAt);
@@ -180,7 +183,7 @@ Analytics.prototype.enqueue = function(type, message, fn){
   });
 
   if (this.queue.length >= this.flushAt) this.flush();
-  if (this.flushAfter && !this.timer)  this.timer = setTimeout(this.flush.bind(this), this.flushAfter);
+  if (this.flushAfter && !this.timer) this.timer = setTimeout(this.flush.bind(this), this.flushAfter);
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -98,17 +98,19 @@ describe('Analytics', function(){
       a.enqueue('type', {});
     });
 
-    it('should reset an existing timer', function(done){
+    it('should not reset an existing timer', function(done){
       var i = 0;
       a.flushAt = Infinity;
-      a.flushAfter = 1;
+      a.flushAfter = 3;
       a.flush = function(){ i++; };
       a.enqueue('type', {});
-      a.enqueue('type', {});
       setTimeout(function(){
+        a.enqueue('type', {});
+      }, 1);
+      setTimeout(function() {
         assert.equal(1, i);
         done();
-      }, 1);
+      }, 4);
     });
 
     it('should extend the given context', function(){


### PR DESCRIPTION
Makes the behavior of the `flushAfter` setting adhere to the documentation to fix #53

```
By default, our library will flush:

The very first time it gets a message.
Every 20 messages (controlled by options.flushAt).
If 10 seconds has passed since the last flush (controlled by options.flushAfter)
```
