### PR TITLE
increase messageId entropy, and include one id per message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
+sudo: false
 language: node_js
-notifications:
-  email:
-    - engineering@segment.io
 node_js:
+  - "4.1"
+  - "4.0"
   - '0.12'

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ var request = require('superagent');
 require('superagent-retry')(request);
 var type = require('component-type');
 var join = require('join-component');
-var uid = require('uid');
+var uid = require('crypto-token');
 var version = require('../package.json').version;
 var extend = require('lodash').extend;
 
@@ -136,8 +136,7 @@ Analytics.prototype.flush = function(fn){
   var data = {
     batch: batch,
     timestamp: new Date(),
-    sentAt: new Date(),
-    messageId: uid(8)
+    sentAt: new Date()
   };
 
   debug('flush: %o', data);
@@ -171,6 +170,7 @@ Analytics.prototype.enqueue = function(type, message, fn){
   message.type = type;
   message.context = extend(message.context || {}, { library: { name: 'analytics-node', version: version }});
   if (!message.timestamp) message.timestamp = new Date();
+  if (!message.messageId) message.messageId = 'node-' + uid(32);
 
   debug('%s: %o', type, message);
   this.queue.push({

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   "dependencies": {
     "clone": "~0.1.17",
     "component-type": "~1.0.0",
+    "crypto-token": "^1.0.1",
+    "debug": "^2.2.0",
     "join-component": "~1.0.0",
     "lodash": "~2.4.1",
     "superagent": "^1.4.0",
     "superagent-proxy": "^1.0.0",
-    "superagent-retry": "^0.5.1",
-    "debug": "^2.2.0",
-    "uid": "0.0.2"
+    "superagent-retry": "^0.5.1"
   },
   "devDependencies": {
     "async": "~0.9.0",


### PR DESCRIPTION
This changes the behavior of setting end-to-end messageIds, so
that the client library now generates individual ones per message
rather than a single group of them per batch.

It also increases the entropy, increasing them to 32 characters.