### PR TITLE
Adding a CLI

### DIFF
--- a/bin/analytics
+++ b/bin/analytics
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+var Analytics = require('..');
+var assert = require('assert');
+var pkg = require('../package.json');
+var program = require('commander');
+
+program
+  .version(pkg.version)
+  .option('-w, --write-key <key>', 'the segment write key to use');
+
+program
+  .command('track <event>')
+  .description('track a user event')
+  .option('-u, --user <id>', 'the user id to send the event as')
+  .option('-a, --anonymous <id>', 'the anonymous user id to send the event as')
+  .option('-p, --properties <data>', 'the event properties to send (JSON-encoded)', toObject)
+  .option('-t, --timestamp <date>', 'the date of the event', toDate)
+  .option('-c, --context <data>', 'additional context for the event (JSON-encoded)', toObject)
+  .action(function(event, options) {
+    run('track', {
+      event: event,
+      userId: options.user,
+      anonymousId: options.anonymous,
+      properties: options.properties,
+      timestamp: options.timestamp,
+      context: options.context
+    });
+  });
+
+program
+  .command('page')
+  .description('track a page view')
+  .option('-u, --user <id>', 'the user id to send the event as')
+  .option('-n, --name <name>', 'the name of the page')
+  .option('-C, --category <category>', 'the category of the page')
+  .option('-p, --properties <data>', 'attributes of the page (JSON-encoded)', toObject)
+  .option('-t, --timestamp <date>', 'the date of the event', toDate)
+  .option('-c, --context <data>', 'additional context for the event (JSON-encoded)', toObject)
+  .action(function(options) {
+    run('page', {
+      userId: options.user,
+      name: options.name,
+      category: options.category,
+      properties: options.properties,
+      timestamp: options.timestamp,
+      context: options.context
+    });
+  });
+
+program
+  .command('identify')
+  .description('identify a user')
+  .option('-u, --user <id>', 'the user id to send the event as')
+  .option('-T, --traits <data>', 'the user traits to send (JSON-encoded)', toObject)
+  .option('-t, --timestamp <date>', 'the date of the event', toDate)
+  .option('-c, --context <data>', 'additional context for the event (JSON-encoded)', toObject)
+  .action(function(options) {
+    run('identify', {
+      userId: options.user,
+      traits: options.traits,
+      timestamp: options.timestamp,
+      context: options.context
+    });
+  });
+
+program
+  .command('group')
+  .description('identify a group of users')
+  .option('-u, --user <id>', 'the user id to send the event as')
+  .option('-a, --anonymous <id>', 'the anonymous id to associate with this group')
+  .option('-g, --group <id>', 'the group id to associate this user with')
+  .option('-T, --traits <data>', 'attributes about the group (JSON-encoded)', toObject)
+  .option('-t, --timestamp <date>', 'the date of the event', toDate)
+  .option('-c, --context <data>', 'additional context for the event (JSON-encoded)', toObject)
+  .action(function(options) {
+    run('group', {
+      userId: options.user,
+      anonymousId: options.anonymous,
+      groupId: options.group,
+      traits: options.traits,
+      timestamp: options.timestamp,
+      context: options.context
+    });
+  });
+
+program
+  .command('alias')
+  .description('remap a user to a new id')
+  .option('-u, --user <id>', 'the user id to send the event as')
+  .option('-p, --previous <id>', 'the previous user id (to add the alias for)')
+  .action(function(options) {
+    run('alias', {
+      userId: options.user,
+      previousId: options.previous
+    });
+  });
+
+program.parse(process.argv);
+
+if (program.args.length === 0) {
+  program.help();
+}
+
+function run(method, options) {
+  var writeKey = process.env.SEGMENT_WRITE_KEY || program.writeKey;
+  assert(writeKey, 'you need to define your write key via the $SEGMENT_WRITE_KEY environment variable or the --write-key flag');
+
+  var analytics = new Analytics(writeKey, { flushAt: 1 });
+
+  analytics[method](options, done);
+}
+
+function toDate(str) {
+  return new Date(str);
+}
+
+function toObject(str) {
+  return JSON.parse(str);
+}
+
+function done(err) {
+  if (err) {
+    console.error(err.stack);
+    process.exit(1);
+  } else {
+    process.exit(0);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,8 +16,12 @@
       "brfs"
     ]
   },
+  "bin": {
+    "analytics": "bin/analytics"
+  },
   "dependencies": {
     "clone": "~0.1.17",
+    "commander": "^2.9.0",
     "component-type": "~1.0.0",
     "crypto-token": "^1.0.1",
     "debug": "^2.2.0",


### PR DESCRIPTION
While working on a revamped simulator, I've decide it's best to create docker containers for each library. In addition, it's way easier `docker run` things that have a CLI, so I've added one here. It also turned out this tool could be useful for success engineers or for debugging, so I've created this as a separate PR after discussing with @calvinfo.

The big idea is that you add a `$SEGMENT_WRITE_KEY` to your env and then you can run the following commands:

```bash
$ analytics track <event> [options]
$ analytics identify [options]
$ analytics group [options]
$ analytics alias [options]
$ analytics page [options]
```

All the options are consistent throughout the commands, which you can see by using `--help`.

**NOTE:** This adds 1 more dependency to `analytics-node` itself, which is [commander](https://www.npmjs.com/package/commander). (it's a lightweight) This does not inflate the browserify build at all. (since it's only being used in the `bin/` dir)