### PR TITLE
improving flush, adding onAllDataFlushed, removing a global

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,10 @@ function Analytics(writeKey, options){
   assert(writeKey, 'You must pass your Segment project\'s write key.');
   options = options || {};
   this.queue = [];
+  this.flushesInProgressCount = 0;
+  this.flushesInProgress = {};
+  this.mostRecentFlushId = null;
+  this.allDataFlushedListeners = [];
   this.writeKey = writeKey;
   this.host = options.host || 'https://api.segment.io';
   this.flushAt = Math.max(options.flushAt, 1) || 20;
@@ -122,16 +126,30 @@ Analytics.prototype.alias = function(message, fn){
  * Flush the current queue and callback `fn(err, batch)`.
  *
  * @param {Function} fn (optional)
- * @return {Analytics}
  */
 
 Analytics.prototype.flush = function(fn){
   fn = fn || noop;
-  if (!this.queue.length) return setImmediate(fn);
+
+  if (!this.queue.length) {
+    // Event though queue is empty, however most recent flush hasn't finished
+    // yet, so it would be misleading to execute the callback, since it
+    // would be fired even though most recent data is still being sent.
+    if (this.flushesInProgressCount) {
+      return this.storeEmptyQueuFlushCallback(fn);
+    }
+
+    return setImmediate(fn);
+  }
+
+  var flushId = this.registerFlushJob();
+
 
   var items = this.queue.splice(0, this.flushAt);
   var fns = items.map(function(_){ return _.callback; });
   var batch = items.map(function(_){ return _.message; });
+
+  var self = this;
 
   var data = {
     batch: batch,
@@ -150,9 +168,39 @@ Analytics.prototype.flush = function(fn){
       err = err || error(res);
       fns.push(fn);
       fns.forEach(function(fn){ fn(err, data); });
+      self.finiliseFlushJob(flushId, err, data);
+      if (!self.flushesInProgressCount && !self.queue.length) {
+        debug('all data flushed, notifying listeners');
+        self.allDataFlushedListeners.forEach(function(fn){ fn(err, data); });
+      }
       debug('flushed: %o', data);
     });
 };
+
+/**
+ * Set listener `fn(err, batch)`, which will be fired once the queue is empty
+ * and all data has finished flushing. You would usually want to call
+ * this after calling flush, for example if you want to wait for all data to
+ * be sent before exiting a script or closing your application.
+ *
+ * The reason we can't simply rely on flush, is that new data might be added
+ * to the queue between the flush is initiated, and the flush callback called.
+ *
+ * The downside of using this function is that it might never fire if new
+ * events are being added constantly. So you need to be sure that event
+ * producers will finish at some point.
+ *
+ *
+ * @param {Function} fn.
+ */
+
+Analytics.prototype.onAllDataFlushed = function(fn){
+
+  if (!this.queue.length && !this.flushesInProgressCount) return setImmediate(fn);
+
+  this.allDataFlushedListeners.push(fn);
+};
+
 
 /**
  * Add a `message` of type `type` to the queue and check whether it should be
@@ -181,6 +229,38 @@ Analytics.prototype.enqueue = function(type, message, fn){
   if (this.queue.length >= this.flushAt) this.flush();
   if (this.timer) clearTimeout(this.timer);
   if (this.flushAfter) this.timer = setTimeout(this.flush.bind(this), this.flushAfter);
+};
+
+/**
+ * @api private
+ */
+Analytics.prototype.storeEmptyQueuFlushCallback = function(fn){
+  var flushId = this.mostRecentFlushId;
+  debug('storeEmptyQueuFlushCallback', flushId);
+  var flushInProgress = this.flushesInProgress[ flushId ];
+
+  flushInProgress.emptyQueueFlushCallbacks.push(fn);
+  debug('storeEmptyQueuFlushCallback emptyQueueFlushCallbacks.length', flushInProgress.emptyQueueFlushCallbacks.length);
+};
+
+Analytics.prototype.registerFlushJob = function(){
+  var flushId = uid(32);
+  debug('registerFlushJob', flushId);
+  this.mostRecentFlushId = flushId;
+  this.flushesInProgress[ flushId ] = { emptyQueueFlushCallbacks : [] };
+  this.flushesInProgressCount++;
+  debug('registerFlushJob flushesInProgressCount', this.flushesInProgressCount);
+  return flushId;
+};
+
+Analytics.prototype.finiliseFlushJob = function(flushId,err,data){
+  debug('finiliseFlushJob', flushId);
+  var fns = this.flushesInProgress[ flushId ].emptyQueueFlushCallbacks;
+  delete this.flushesInProgress[ flushId ];
+  this.flushesInProgressCount--;
+  debug('finiliseFlushJob flushesInProgressCount', this.flushesInProgressCount);
+  debug('fns.length', fns.length);
+  fns.forEach(function(fn){ fn(err, data); });
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ var uid = require('crypto-token');
 var version = require('../package.json').version;
 var extend = require('lodash').extend;
 
-global.setImmediate = global.setImmediate || process.nextTick.bind(process);
+var setImmediate = global.setImmediate || process.nextTick.bind(process);
 
 /**
  * Expose an `Analytics` client.

--- a/lib/index.js
+++ b/lib/index.js
@@ -239,8 +239,12 @@ Analytics.prototype.storeEmptyQueuFlushCallback = function(fn){
   debug('storeEmptyQueuFlushCallback', flushId);
   var flushInProgress = this.flushesInProgress[ flushId ];
 
-  flushInProgress.emptyQueueFlushCallbacks.push(fn);
-  debug('storeEmptyQueuFlushCallback emptyQueueFlushCallbacks.length', flushInProgress.emptyQueueFlushCallbacks.length);
+  if (flushInProgress) {
+    flushInProgress.emptyQueueFlushCallbacks.push(fn);
+    debug('storeEmptyQueuFlushCallback emptyQueueFlushCallbacks.length', flushInProgress.emptyQueueFlushCallbacks.length);
+  } else {
+    debug('storeEmptyQueuFlushCallback no flushesInProgress found for id', flushId);
+  }
 };
 
 Analytics.prototype.registerFlushJob = function(){


### PR DESCRIPTION
1. flush : when calling twice one after another ( or when flush called
   manually directly follows a flush triggered internally ), the second
   flush would trigger its callback before the previous could finish
   sending its data. This is misleading since you would usually expect
   data data you have just enqueued, has been safely uploaded once the
   flush callback is called. The commit improves this behaviour by waiting
   for currently pending flush to finish before executing the callback of
   the consecutive flush ( as long as there was no events in the queue when
   the second flush was called ).
2. onAllDataFlushed : even with the above improvement, if we rally want
   to be sure that there is no pending data ( for example if we want to
   close the app ), we need to do a little bit more work, since even though
   a flush is done, it doesn’t mean that new data has not been queued and
   flushed in the meantime ( between a call to flush and it callback ).
   onAllDataFlushed registers a callback ( listener ) which fires once,
   whenever a flush is done and there are no more messages in the queue.
3. replacing setImmediate global with local var : there is no reason to set a global in order to use this function within the lib. Its not nice for an npm module to do that
