### PR TITLE
Replace validation with `@segment/loosely-validate-event`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,11 +4,10 @@ var debug = require('debug')('analytics-node');
 var noop = function(){};
 var request = require('superagent');
 require('superagent-retry')(request);
-var type = require('component-type');
-var join = require('join-component');
 var uid = require('crypto-token');
 var version = require('../package.json').version;
 var extend = require('lodash').extend;
+var validate = require('@segment/loosely-validate-event');
 
 global.setImmediate = global.setImmediate || process.nextTick.bind(process);
 
@@ -49,8 +48,7 @@ function Analytics(writeKey, options){
  */
 
 Analytics.prototype.identify = function(message, fn){
-  validate(message);
-  assert(message.anonymousId || message.userId, 'You must pass either an "anonymousId" or a "userId".');
+  validate(message, 'identify');
   this.enqueue('identify', message, fn);
   return this;
 };
@@ -64,9 +62,7 @@ Analytics.prototype.identify = function(message, fn){
  */
 
 Analytics.prototype.group = function(message, fn){
-  validate(message);
-  assert(message.anonymousId || message.userId, 'You must pass either an "anonymousId" or a "userId".');
-  assert(message.groupId, 'You must pass a "groupId".');
+  validate(message, 'group');
   this.enqueue('group', message, fn);
   return this;
 };
@@ -80,9 +76,7 @@ Analytics.prototype.group = function(message, fn){
  */
 
 Analytics.prototype.track = function(message, fn){
-  validate(message);
-  assert(message.anonymousId || message.userId, 'You must pass either an "anonymousId" or a "userId".');
-  assert(message.event, 'You must pass an "event".');
+  validate(message, 'track');
   this.enqueue('track', message, fn);
   return this;
 };
@@ -96,8 +90,7 @@ Analytics.prototype.track = function(message, fn){
  */
 
 Analytics.prototype.page = function(message, fn){
-  validate(message);
-  assert(message.anonymousId || message.userId, 'You must pass either an "anonymousId" or a "userId".');
+  validate(message, 'page');
   this.enqueue('page', message, fn);
   return this;
 };
@@ -111,9 +104,7 @@ Analytics.prototype.page = function(message, fn){
  */
 
 Analytics.prototype.alias = function(message, fn){
-  validate(message);
-  assert(message.userId, 'You must pass a "userId".');
-  assert(message.previousId, 'You must pass a "previousId".');
+  validate(message, 'alias');
   this.enqueue('alias', message, fn);
   return this;
 };
@@ -181,41 +172,6 @@ Analytics.prototype.enqueue = function(type, message, fn){
   if (this.queue.length >= this.flushAt) this.flush();
   if (this.timer) clearTimeout(this.timer);
   if (this.flushAfter) this.timer = setTimeout(this.flush.bind(this), this.flushAfter);
-};
-
-/**
- * Validation rules.
- */
-
-var rules = {
-  anonymousId: ['string', 'number'],
-  category: 'string',
-  context: 'object',
-  event: 'string',
-  groupId: ['string', 'number'],
-  integrations: 'object',
-  name: 'string',
-  previousId: ['string', 'number'],
-  timestamp: 'date',
-  userId: ['string', 'number']
-};
-
-/**
- * Validate an options `obj`.
- *
- * @param {Object} obj
- */
-
-function validate(obj){
-  assert('object' == type(obj), 'You must pass a message object.');
-  for (var key in rules) {
-    var val = obj[key];
-    if (!val) continue;
-    var exp = rules[key];
-    exp = ('array' === type(exp) ? exp : [exp]);
-    var a = 'object' == exp ? 'an' : 'a';
-    assert(exp.some(function(e){ return type(val) === e; }), '"' + key + '" must be ' + a + ' ' + join(exp, 'or') + '.');
-  }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -20,12 +20,11 @@
     "analytics": "bin/analytics"
   },
   "dependencies": {
+    "@segment/loosely-validate-event": "^1.1.1",
     "clone": "~2.1.0",
     "commander": "^2.9.0",
-    "component-type": "~1.2.1",
     "crypto-token": "^1.0.1",
     "debug": "^2.2.0",
-    "join-component": "~1.1.0",
     "lodash": "~4.17.2",
     "superagent": "^3.0.0",
     "superagent-proxy": "^1.0.0",


### PR DESCRIPTION
I needed this validation logic elsewhere, so I pulled it out and moved it to the [loosely-validate-event](https://github.com/segmentio/loosely-validate-event) module. The code is basically a 1:1, just stylistic changes. This patch pulls in this new module and offloads all validation logic to it.

@segmentio/gateway 