### PR TITLE
remove trailing slash on `.host`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var uid = require('crypto-token');
 var version = require('../package.json').version;
 var extend = require('lodash').extend;
 var validate = require('@segment/loosely-validate-event');
+var removeSlash = require('remove-trailing-slash');
 
 global.setImmediate = global.setImmediate || process.nextTick.bind(process);
 
@@ -34,7 +35,7 @@ function Analytics(writeKey, options){
   options = options || {};
   this.queue = [];
   this.writeKey = writeKey;
-  this.host = options.host || 'https://api.segment.io';
+  this.host = removeSlash(options.host || 'https://api.segment.io');
   this.flushAt = Math.max(options.flushAt, 1) || 20;
   this.flushAfter = options.flushAfter || 10000;
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "crypto-token": "^1.0.1",
     "debug": "^2.2.0",
     "lodash": "~4.17.2",
+    "remove-trailing-slash": "^0.1.0",
     "superagent": "^3.0.0",
     "superagent-proxy": "^1.0.0",
     "superagent-retry": "^0.6.0"

--- a/test/index.js
+++ b/test/index.js
@@ -52,6 +52,11 @@ describe('Analytics', function(){
     assert.equal(a.flushAfter, 10000);
   });
 
+  it('should remove trailing slashes from `.host`', function(){
+    var a = Analytics('key', { host: 'http://google.com/////' });
+    assert.equal(a.host, 'http://google.com')
+  });
+
   it('should take options', function(){
     var a = Analytics('key', {
       host: 'a',


### PR DESCRIPTION
I just spent over an hour trying to figure out why an event wasn't showing up. The reason was I was POSTing to `https://api.segment.tld//v1/batch` rather than `https://api.segment.tld/v1/batch`.

@segmentio/gateway @fouad 