### PR TITLE
use correct optional syntax for JSDOC

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ module.exports = Analytics;
  * optional dictionary of `options`.
  *
  * @param {String} writeKey
- * @param {Object} options (optional)
+ * @param {Object} [options] (optional)
  *   @property {Number} flushAt (default: 20)
  *   @property {Number} flushAfter (default: 10000)
  *   @property {String} host (default: 'https://api.segment.io')
@@ -44,7 +44,7 @@ function Analytics(writeKey, options){
  * Send an identify `message`.
  *
  * @param {Object} message
- * @param {Function} fn (optional)
+ * @param {Function} [fn] (optional)
  * @return {Analytics}
  */
 
@@ -58,7 +58,7 @@ Analytics.prototype.identify = function(message, fn){
  * Send a group `message`.
  *
  * @param {Object} message
- * @param {Function} fn (optional)
+ * @param {Function} [fn] (optional)
  * @return {Analytics}
  */
 
@@ -72,7 +72,7 @@ Analytics.prototype.group = function(message, fn){
  * Send a track `message`.
  *
  * @param {Object} message
- * @param {Function} fn (optional)
+ * @param {Function} [fn] (optional)
  * @return {Analytics}
  */
 
@@ -86,7 +86,7 @@ Analytics.prototype.track = function(message, fn){
  * Send a page `message`.
  *
  * @param {Object} message
- * @param {Function} fn (optional)
+ * @param {Function} [fn] (optional)
  * @return {Analytics}
  */
 
@@ -100,7 +100,7 @@ Analytics.prototype.page = function(message, fn){
  * Send an alias `message`.
  *
  * @param {Object} message
- * @param {Function} fn (optional)
+ * @param {Function} [fn] (optional)
  * @return {Analytics}
  */
 
@@ -113,7 +113,7 @@ Analytics.prototype.alias = function(message, fn){
 /**
  * Flush the current queue and callback `fn(err, batch)`.
  *
- * @param {Function} fn (optional)
+ * @param {Function} [fn] (optional)
  * @return {Analytics}
  */
 
@@ -152,7 +152,7 @@ Analytics.prototype.flush = function(fn){
  *
  * @param {String} type
  * @param {Object} message
- * @param {Functino} fn (optional)
+ * @param {Functino} [fn] (optional)
  * @api private
  */
 


### PR DESCRIPTION
Keeps various dev tools from complaining about missing parameters: http://usejsdoc.org/tags-param.html#optional-parameters-and-default-values