### PR TITLE
Add node version to messages via _metadata

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -160,7 +160,14 @@ Analytics.prototype.enqueue = function(type, message, fn){
   fn = fn || noop;
   message = clone(message);
   message.type = type;
-  message.context = extend(message.context || {}, { library: { name: 'analytics-node', version: version }});
+  message.context = extend(message.context || {}, {
+    library: {
+      name: 'analytics-node',
+      version: version,
+      nodeVersion: process.versions.node
+    }
+  });
+
   if (!message.timestamp) message.timestamp = new Date();
   if (!message.messageId) message.messageId = 'node-' + uid(32);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -164,9 +164,10 @@ Analytics.prototype.enqueue = function(type, message, fn){
     library: {
       name: 'analytics-node',
       version: version,
-      nodeVersion: process.versions.node
     }
   });
+
+  message._metadata = extend(message._metadata || {}, { nodeVersion: process.versions.node });
 
   if (!message.timestamp) message.timestamp = new Date();
   if (!message.messageId) message.messageId = 'node-' + uid(32);

--- a/test/index.js
+++ b/test/index.js
@@ -10,8 +10,7 @@ var id = 'id';
 var context = {
   library: {
     name: 'analytics-node',
-    version: require('../package.json').version,
-    nodeVersion: process.versions.node
+    version: require('../package.json').version
   }
 };
 
@@ -128,8 +127,7 @@ describe('Analytics', function(){
       assert.deepEqual(a.queue[0].message.context, {
         library: {
           name:'analytics-node',
-          version: require('../package.json').version,
-          nodeVersion: process.versions.node
+          version: require('../package.json').version
         },
         name: 'travis'
       });
@@ -179,7 +177,8 @@ describe('Analytics', function(){
         userId: 'id',
         timestamp: date,
         context: context,
-        messageId: id
+        messageId: id,
+        _metadata: { nodeVersion: process.versions.node }
       });
     });
 
@@ -204,7 +203,8 @@ describe('Analytics', function(){
         groupId: 'group',
         timestamp: date,
         context: context,
-        messageId: id
+        messageId: id,
+        _metadata: { nodeVersion: process.versions.node }
       });
     });
 
@@ -235,7 +235,8 @@ describe('Analytics', function(){
         userId: 'id',
         timestamp: date,
         context: context,
-        messageId: id
+        messageId: id,
+        _metadata: { nodeVersion: process.versions.node }
       });
     });
 
@@ -248,7 +249,8 @@ describe('Analytics', function(){
         type: 'track',
         timestamp: date,
         context: context,
-        messageId: id
+        messageId: id,
+        _metadata: { nodeVersion: process.versions.node }
       })
     });
 
@@ -278,7 +280,8 @@ describe('Analytics', function(){
         userId: 'id',
         timestamp: date,
         context: context,
-        messageId: id
+        messageId: id,
+        _metadata: { nodeVersion: process.versions.node }
       });
     });
 
@@ -303,7 +306,8 @@ describe('Analytics', function(){
         userId: 'id',
         timestamp: date,
         context: context,
-        messageId: id
+        messageId: id,
+        _metadata: { nodeVersion: process.versions.node }
       });
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -6,10 +6,12 @@ var server = require('./server');
 var a;
 var noop = function(){};
 var id = 'id';
+
 var context = {
   library: {
     name: 'analytics-node',
-    version: require('../package.json').version
+    version: require('../package.json').version,
+    nodeVersion: process.versions.node
   }
 };
 
@@ -126,7 +128,8 @@ describe('Analytics', function(){
       assert.deepEqual(a.queue[0].message.context, {
         library: {
           name:'analytics-node',
-          version: require('../package.json').version
+          version: require('../package.json').version,
+          nodeVersion: process.versions.node
         },
         name: 'travis'
       });


### PR DESCRIPTION
FIx #79 :)

I first tried to add it to the context, as it's where the library version is, but per #79 it should be in `_metadata`.

CC: @myclamm 

(mostly based on this github search: https://github.com/search?q=org%3Asegmentio+_metadata&type=Code)