### PR TITLE
replace Travis with CircleCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-language: node_js
-node_js:
-  - "4.1"
-  - "4.0"
-  - '0.12'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 #analytics-node
 
-[![Build Status](https://api.travis-ci.org/segmentio/analytics-node.svg?branch=master)](https://travis-ci.org/segmentio/analytics-node)
+[![CircleCI](https://circleci.com/gh/segmentio/analytics-node.svg?style=svg)](https://circleci.com/gh/segmentio/analytics-node)
 
 A node.js client for [Segment](https://segment.com) — The hassle-free way to integrate analytics into any application.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,4 +1,13 @@
-Releasing
-=========
+# Releasing
 
-1. Run `robo npm.publish <major|minor|patch|version>`.
+To cut a release, do:
+
+```
+$ git changelog --tag <version>
+$ vim package.json # update ".version"
+$ git release <version>
+```
+
+Where `<version>` represents a valid [semver](http://semver.org) version number.
+
+CircleCI will handle rebuilding `analytics-node.js` and publishing to npm for you.sion>`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,4 +10,4 @@ $ git release <version>
 
 Where `<version>` represents a valid [semver](http://semver.org) version number.
 
-CircleCI will handle rebuilding `analytics-node.js` and publishing to npm for you.sion>`.
+CircleCI will handle rebuilding `analytics-node.js` and publishing to npm for you.

--- a/circle.yml
+++ b/circle.yml
@@ -18,10 +18,10 @@ dependencies:
 
 test:
   override:
-    - nvm use 0.12; npm rebuild; make test
-    - nvm use 4.1; npm rebuild; make test
-    - nvm use 4; npm rebuild; make test
-    - nvm use 6; npm rebuild; make test
+    - nvm use 0.12; npm rebuild > /dev/null; make test
+    - nvm use 4.1; npm rebuild > /dev/null; make test
+    - nvm use 4; npm rebuild > /dev/null; make test
+    - nvm use 6; npm rebuild > /dev/null; make test
 
 deployment:
   publish:

--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,6 @@ deployment:
     commands:
       - make analytics-node.js
       - git add analytics-node.js
-      - git commit -m "analytics-node.js@$CIRCLE_TAG"
+      - git commit -m "analytics-node.js@$CIRCLE_TAG [ci skip]"
       - git push origin master
       - npm publish

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ test:
 
 deployment:
   publish:
-    tag: /v?[0-9]+(\.[0-9]+)*(-.+)?/
+    tag: /[0-9]+\.[0-9]+\.[0-9]+/
     commands:
       - make analytics-node.js
       - git add analytics-node.js

--- a/circle.yml
+++ b/circle.yml
@@ -30,4 +30,5 @@ deployment:
       - make analytics-node.js
       - git add analytics-node.js
       - git commit -m "analytics-node.js@$CIRCLE_TAG"
+      - git push origin master
       - npm publish

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,33 @@
+machine:
+  node:
+    version: 6
+
+checkout:
+  post:
+    - npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
+    - git config user.name "SegmentBot"
+    - git config user.email "tools+segmentbot@segment.com"
+
+dependencies:
+  override:
+    - make node_modules
+    - nvm install 0.12
+    - nvm install 4.1
+    - nvm install 4
+    - nvm install 6
+
+test:
+  override:
+    - nvm use 0.12; npm rebuild; make test
+    - nvm use 4.1; npm rebuild; make test
+    - nvm use 4; npm rebuild; make test
+    - nvm use 6; npm rebuild; make test
+
+deployment:
+  publish:
+    tag: /v?[0-9]+(\.[0-9]+)*(-.+)?/
+    commands:
+      - make analytics-node.js
+      - git add analytics-node.js
+      - git commit -m "analytics-node.js@$CIRCLE_TAG"
+      - npm publish


### PR DESCRIPTION
This patch replaces Travis with CircleCI. This prevents the context-switching between Travis and Circle (since we use Circle for nearly everything else), and gives us more flexibility for handling builds.

This patch also introduces automatically published builds (to npm) and automatically generated `analytics-node.js` versions.

Closes #80.

@segmentio/gateway 

----

NOTE - Travis build is failing because I removed the `.travis.yml` file. Once approved, I'll disable Travis and rebuild.