### PR TITLE
test: add `_metadata` to "screen" assertion

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -305,7 +305,8 @@ describe('Analytics', function(){
         userId: 'id',
         timestamp: date,
         context: context,
-        messageId: id
+        messageId: id,
+        _metadata: { nodeVersion: process.versions.node }
       });
     });
 


### PR DESCRIPTION
#82 was merged _after_ #84, so the "screen" test didn't exist (therefore couldn't be "fixed").

@segmentio/gateway