### PR TITLE
add `mock.js`

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -1,0 +1,25 @@
+var Analytics = require('./')
+
+var temp = new Analytics('fakekey')
+
+module.exports = AnalyticsMock
+
+function AnalyticsMock () {
+  if (!(this instanceof AnalyticsMock)) {
+    return new AnalyticsMock()
+  }
+}
+
+for (var key in temp) {
+  var fn = temp[key]
+  if (typeof fn === 'function') {
+    AnalyticsMock.prototype[key] = mock
+  }
+}
+
+function mock () {
+  var callback = arguments[arguments.length - 1]
+  if (typeof callback === 'function') {
+    process.nextTick(callback)
+  }
+}

--- a/test/mock.js
+++ b/test/mock.js
@@ -1,0 +1,27 @@
+/* global describe, it */
+
+var assert = require('assert')
+var AnalyticsMock = require('../mock')
+
+describe('AnalyticsMock', function () {
+  it('should not require `new`', function () {
+    var mock = AnalyticsMock()
+    assert(mock instanceof AnalyticsMock)
+  })
+
+  it('should expose all methods', function () {
+    var mock = new AnalyticsMock()
+    assert.equal(typeof mock.identify, 'function')
+    assert.equal(typeof mock.group, 'function')
+    assert.equal(typeof mock.track, 'function')
+    assert.equal(typeof mock.page, 'function')
+    assert.equal(typeof mock.screen, 'function')
+    assert.equal(typeof mock.alias, 'function')
+    assert.equal(typeof mock.flush, 'function')
+  })
+
+  it('should callback', function (done) {
+    var mock = new AnalyticsMock()
+    mock.track({ foo: 'bar' }, done)
+  })
+})


### PR DESCRIPTION
This patch adds a `mock.js` file, which we'll be able to use in
development/test/etc (anywhere you don't want to send real events).

I'm envisioning usage looking something like:

```js
const { NODE_ENV = 'development' } = process.env

const Analytics = NODE_ENV === 'production'
  ? require('analytics-node')
  : require('analytics-node/mock')
const analytics = new Analytics('abc write key', { some: 'options' })

analytics.track({ userId: 'aaa', event: 'Did Something' })
```

@segmentio/gateway @thesmart 

Closes #75.