### PR TITLE
Reset timer on flush

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -133,12 +133,12 @@ Analytics.prototype.alias = function (message, fn) {
 
 Analytics.prototype.flush = function (fn) {
   fn = fn || noop
-  
+
   if (this.timer) {
     clearTimeout(this.timer)
     this.timer = null
   }
-  
+
   if (!this.queue.length) return setImmediate(fn)
 
   var items = this.queue.splice(0, this.flushAt)

--- a/lib/index.js
+++ b/lib/index.js
@@ -133,6 +133,12 @@ Analytics.prototype.alias = function (message, fn) {
 
 Analytics.prototype.flush = function (fn) {
   fn = fn || noop
+  
+  if (this.timer) {
+    clearTimeout(this.timer)
+    this.timer = null
+  }
+  
   if (!this.queue.length) return setImmediate(fn)
 
   var items = this.queue.splice(0, this.flushAt)
@@ -193,8 +199,7 @@ Analytics.prototype.enqueue = function (type, message, fn) {
   })
 
   if (this.queue.length >= this.flushAt) this.flush()
-  if (this.timer) clearTimeout(this.timer)
-  if (this.flushAfter) this.timer = setTimeout(this.flush.bind(this), this.flushAfter)
+  if (this.flushAfter && !this.timer) this.timer = setTimeout(this.flush.bind(this), this.flushAfter)
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -116,11 +116,11 @@ describe('Analytics', function () {
       a.flushAfter = 10
       a.flush = function () { i++ }
       a.enqueue('type', {})
-      
+
       setTimeout(function () {
         a.enqueue('type', {})
       }, 5)
-      
+
       setTimeout(function () {
         assert.equal(1, i)
         done()

--- a/test/index.js
+++ b/test/index.js
@@ -110,17 +110,21 @@ describe('Analytics', function () {
       a.enqueue('type', {})
     })
 
-    it('should reset an existing timer', function (done) {
+    it('should not reset an existing timer', function (done) {
       var i = 0
       a.flushAt = Infinity
-      a.flushAfter = 1
+      a.flushAfter = 10
       a.flush = function () { i++ }
       a.enqueue('type', {})
-      a.enqueue('type', {})
+      
+      setTimeout(function () {
+        a.enqueue('type', {})
+      }, 5)
+      
       setTimeout(function () {
         assert.equal(1, i)
         done()
-      }, 1)
+      }, 10)
     })
 
     it('should extend the given context', function () {


### PR DESCRIPTION
Follow up to @nathanpeck's work on https://github.com/segmentio/analytics-node/pull/54. Rebased and modified a test.

To recap, this PR makes reset timer work as an interval, instead of resetting it on each `enqueue()` call.