### PR TITLE
Convert to ES6

### DIFF
--- a/bin/analytics
+++ b/bin/analytics
@@ -1,9 +1,26 @@
 #!/usr/bin/env node
+'use strict'
 
-var Analytics = require('..')
-var assert = require('assert')
-var pkg = require('../package.json')
-var program = require('commander')
+const assert = require('assert')
+const program = require('commander')
+const Analytics = require('..')
+const pkg = require('../package')
+
+const run = (method, options) => {
+  const writeKey = process.env.SEGMENT_WRITE_KEY || program.writeKey
+  assert(writeKey, 'You need to define your write key via the $SEGMENT_WRITE_KEY environment variable or the --write-key flag.')
+
+  const analytics = new Analytics(writeKey, { flushAt: 1 })
+  analytics[method](options, err => {
+    if (err) {
+      console.error(err.stack)
+      process.exit(1)
+    }
+  })
+}
+
+const toDate = str => new Date(str)
+const toObject = str => JSON.parse(str)
 
 program
   .version(pkg.version)
@@ -17,9 +34,9 @@ program
   .option('-p, --properties <data>', 'the event properties to send (JSON-encoded)', toObject)
   .option('-t, --timestamp <date>', 'the date of the event', toDate)
   .option('-c, --context <data>', 'additional context for the event (JSON-encoded)', toObject)
-  .action(function (event, options) {
+  .action((event, options) => {
     run('track', {
-      event: event,
+      event,
       userId: options.user,
       anonymousId: options.anonymous,
       properties: options.properties,
@@ -37,7 +54,7 @@ program
   .option('-p, --properties <data>', 'attributes of the page (JSON-encoded)', toObject)
   .option('-t, --timestamp <date>', 'the date of the event', toDate)
   .option('-c, --context <data>', 'additional context for the event (JSON-encoded)', toObject)
-  .action(function (options) {
+  .action(options => {
     run('page', {
       userId: options.user,
       name: options.name,
@@ -55,7 +72,7 @@ program
   .option('-T, --traits <data>', 'the user traits to send (JSON-encoded)', toObject)
   .option('-t, --timestamp <date>', 'the date of the event', toDate)
   .option('-c, --context <data>', 'additional context for the event (JSON-encoded)', toObject)
-  .action(function (options) {
+  .action(options => {
     run('identify', {
       userId: options.user,
       traits: options.traits,
@@ -73,7 +90,7 @@ program
   .option('-T, --traits <data>', 'attributes about the group (JSON-encoded)', toObject)
   .option('-t, --timestamp <date>', 'the date of the event', toDate)
   .option('-c, --context <data>', 'additional context for the event (JSON-encoded)', toObject)
-  .action(function (options) {
+  .action(options => {
     run('group', {
       userId: options.user,
       anonymousId: options.anonymous,
@@ -89,7 +106,7 @@ program
   .description('remap a user to a new id')
   .option('-u, --user <id>', 'the user id to send the event as')
   .option('-p, --previous <id>', 'the previous user id (to add the alias for)')
-  .action(function (options) {
+  .action(options => {
     run('alias', {
       userId: options.user,
       previousId: options.previous
@@ -100,30 +117,4 @@ program.parse(process.argv)
 
 if (program.args.length === 0) {
   program.help()
-}
-
-function run (method, options) {
-  var writeKey = process.env.SEGMENT_WRITE_KEY || program.writeKey
-  assert(writeKey, 'you need to define your write key via the $SEGMENT_WRITE_KEY environment variable or the --write-key flag')
-
-  var analytics = new Analytics(writeKey, { flushAt: 1 })
-
-  analytics[method](options, done)
-}
-
-function toDate (str) {
-  return new Date(str)
-}
-
-function toObject (str) {
-  return JSON.parse(str)
-}
-
-function done (err) {
-  if (err) {
-    console.error(err.stack)
-    process.exit(1)
-  } else {
-    process.exit(0)
-  }
 }

--- a/circle.yml
+++ b/circle.yml
@@ -5,9 +5,9 @@ machine:
 dependencies:
   pre:
     - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.21.3
-    - nvm install 4.1
     - nvm install 4
     - nvm install 6
+    - nvm install 8
   cache_directories:
     - ~/.yarn-cache
   override:
@@ -17,6 +17,6 @@ test:
   override:
     - make lint
     - node_modules/.bin/nsp check
-    - nvm use 4.1; npm rebuild > /dev/null; make test
     - nvm use 4; npm rebuild > /dev/null; make test
     - nvm use 6; npm rebuild > /dev/null; make test
+    - nvm use 8; npm rebuild > /dev/null; make test

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,205 +1,15 @@
-var assert = require('assert')
-var clone = require('clone')
-var debug = require('debug')('analytics-node')
-var noop = function () {}
-var request = require('superagent')
-var uid = require('crypto-token')
-var version = require('../package.json').version
-var extend = require('lodash/extend')
-var validate = require('@segment/loosely-validate-event')
-var removeSlash = require('remove-trailing-slash')
+'use strict'
 
-global.setImmediate = global.setImmediate || process.nextTick.bind(process)
+const assert = require('assert')
+const removeSlash = require('remove-trailing-slash')
+const validate = require('@segment/loosely-validate-event')
+const request = require('superagent')
+const debug = require('debug')('analytics-node')
+const uid = require('crypto-token')
+const version = require('../package').version
 
-/**
- * Expose an `Analytics` client.
- */
-
-module.exports = Analytics
-
-/**
- * Initialize a new `Analytics` with your Segment project's `writeKey` and an
- * optional dictionary of `options`.
- *
- * @param {String} writeKey
- * @param {Object} [options] (optional)
- *   @property {Number} flushAt (default: 20)
- *   @property {Number} flushAfter (default: 10000)
- *   @property {String} host (default: 'https://api.segment.io')
- */
-
-function Analytics (writeKey, options) {
-  if (!(this instanceof Analytics)) return new Analytics(writeKey, options)
-  assert(writeKey, 'You must pass your Segment project\'s write key.')
-  options = options || {}
-  this.queue = []
-  this.writeKey = writeKey
-  this.host = removeSlash(options.host || 'https://api.segment.io')
-  this.flushAt = Math.max(options.flushAt, 1) || 20
-  this.flushAfter = options.flushAfter || 10000
-}
-
-/**
- * Send an identify `message`.
- *
- * @param {Object} message
- * @param {Function} [fn] (optional)
- * @return {Analytics}
- */
-
-Analytics.prototype.identify = function (message, fn) {
-  validate(message, 'identify')
-  this.enqueue('identify', message, fn)
-  return this
-}
-
-/**
- * Send a group `message`.
- *
- * @param {Object} message
- * @param {Function} [fn] (optional)
- * @return {Analytics}
- */
-
-Analytics.prototype.group = function (message, fn) {
-  validate(message, 'group')
-  this.enqueue('group', message, fn)
-  return this
-}
-
-/**
- * Send a track `message`.
- *
- * @param {Object} message
- * @param {Function} [fn] (optional)
- * @return {Analytics}
- */
-
-Analytics.prototype.track = function (message, fn) {
-  validate(message, 'track')
-  this.enqueue('track', message, fn)
-  return this
-}
-
-/**
- * Send a page `message`.
- *
- * @param {Object} message
- * @param {Function} [fn] (optional)
- * @return {Analytics}
- */
-
-Analytics.prototype.page = function (message, fn) {
-  validate(message, 'page')
-  this.enqueue('page', message, fn)
-  return this
-}
-
-/**
- * Send a screen `message`.
- *
- * @param {Object} message
- * @param {Function} fn (optional)
- * @return {Analytics}
- */
-
-Analytics.prototype.screen = function (message, fn) {
-  validate(message, 'screen')
-  this.enqueue('screen', message, fn)
-  return this
-}
-
-/**
- * Send an alias `message`.
- *
- * @param {Object} message
- * @param {Function} [fn] (optional)
- * @return {Analytics}
- */
-
-Analytics.prototype.alias = function (message, fn) {
-  validate(message, 'alias')
-  this.enqueue('alias', message, fn)
-  return this
-}
-
-/**
- * Flush the current queue and callback `fn(err, batch)`.
- *
- * @param {Function} [fn] (optional)
- * @return {Analytics}
- */
-
-Analytics.prototype.flush = function (fn) {
-  fn = fn || noop
-
-  if (this.timer) {
-    clearTimeout(this.timer)
-    this.timer = null
-  }
-
-  if (!this.queue.length) return setImmediate(fn)
-
-  var items = this.queue.splice(0, this.flushAt)
-  var fns = items.map(function (_) { return _.callback })
-  var batch = items.map(function (_) { return _.message })
-
-  var data = {
-    batch: batch,
-    timestamp: new Date(),
-    sentAt: new Date()
-  }
-
-  debug('flush: %o', data)
-
-  request
-    .post(this.host + '/v1/batch')
-    .auth(this.writeKey, '')
-    .retry(3)
-    .send(data)
-    .end(function (err, res) {
-      err = err || error(res)
-      fns.forEach(function (fn) { fn(err) })
-      fn(err, data)
-      debug('flushed: %o', data)
-    })
-}
-
-/**
- * Add a `message` of type `type` to the queue and check whether it should be
- * flushed.
- *
- * @param {String} type
- * @param {Object} message
- * @param {Functino} [fn] (optional)
- * @api private
- */
-
-Analytics.prototype.enqueue = function (type, message, fn) {
-  fn = fn || noop
-  message = clone(message)
-  message.type = type
-  message.context = extend(message.context || {}, {
-    library: {
-      name: 'analytics-node',
-      version: version
-    }
-  })
-
-  message._metadata = extend(message._metadata || {}, { nodeVersion: process.versions.node })
-
-  if (!message.timestamp) message.timestamp = new Date()
-  if (!message.messageId) message.messageId = 'node-' + uid(32)
-
-  debug('%s: %o', type, message)
-  this.queue.push({
-    message: message,
-    callback: fn
-  })
-
-  if (this.queue.length >= this.flushAt) this.flush()
-  if (this.flushAfter && !this.timer) this.timer = setTimeout(this.flush.bind(this), this.flushAfter)
-}
+const setImmediate = global.setImmediate || process.nextTick.bind(process)
+const noop = () => {}
 
 /**
  * Get an error from a `res`.
@@ -208,9 +18,217 @@ Analytics.prototype.enqueue = function (type, message, fn) {
  * @return {String}
  */
 
-function error (res) {
-  if (!res.error) return
-  var body = res.body
-  var msg = (body.error && body.error.message) || res.status + ' ' + res.text
+const error = res => {
+  if (!res.error) {
+    return
+  }
+
+  const body = res.body
+  const msg = (body.error && body.error.message) || `${res.status} ${res.text}`
+
   return new Error(msg)
 }
+
+class Analytics {
+  /**
+   * Initialize a new `Analytics` with your Segment project's `writeKey` and an
+   * optional dictionary of `options`.
+   *
+   * @param {String} writeKey
+   * @param {Object} [options] (optional)
+   *   @property {Number} flushAt (default: 20)
+   *   @property {Number} flushAfter (default: 10000)
+   *   @property {String} host (default: 'https://api.segment.io')
+   */
+
+  constructor (writeKey, options) {
+    options = options || {}
+
+    assert(writeKey, 'You must pass your Segment project\'s write key.')
+
+    this.queue = []
+    this.writeKey = writeKey
+    this.host = removeSlash(options.host || 'https://api.segment.io')
+    this.flushAt = Math.max(options.flushAt, 1) || 20
+    this.flushAfter = options.flushAfter || 10000
+  }
+
+  /**
+   * Send an identify `message`.
+   *
+   * @param {Object} message
+   * @param {Function} [callback] (optional)
+   * @return {Analytics}
+   */
+
+  identify (message, callback) {
+    validate(message, 'identify')
+    this.enqueue('identify', message, callback)
+    return this
+  }
+
+  /**
+   * Send a group `message`.
+   *
+   * @param {Object} message
+   * @param {Function} [callback] (optional)
+   * @return {Analytics}
+   */
+
+  group (message, callback) {
+    validate(message, 'group')
+    this.enqueue('group', message, callback)
+    return this
+  }
+
+  /**
+   * Send a track `message`.
+   *
+   * @param {Object} message
+   * @param {Function} [callback] (optional)
+   * @return {Analytics}
+   */
+
+  track (message, callback) {
+    validate(message, 'track')
+    this.enqueue('track', message, callback)
+    return this
+  }
+
+  /**
+   * Send a page `message`.
+   *
+   * @param {Object} message
+   * @param {Function} [callback] (optional)
+   * @return {Analytics}
+   */
+
+  page (message, callback) {
+    validate(message, 'page')
+    this.enqueue('page', message, callback)
+    return this
+  }
+
+  /**
+   * Send a screen `message`.
+   *
+   * @param {Object} message
+   * @param {Function} fn (optional)
+   * @return {Analytics}
+   */
+
+  screen (message, callback) {
+    validate(message, 'screen')
+    this.enqueue('screen', message, callback)
+    return this
+  }
+
+  /**
+   * Send an alias `message`.
+   *
+   * @param {Object} message
+   * @param {Function} [callback] (optional)
+   * @return {Analytics}
+   */
+
+  alias (message, callback) {
+    validate(message, 'alias')
+    this.enqueue('alias', message, callback)
+    return this
+  }
+
+  /**
+   * Add a `message` of type `type` to the queue and
+   * check whether it should be flushed.
+   *
+   * @param {String} type
+   * @param {Object} message
+   * @param {Functino} [callback] (optional)
+   * @api private
+   */
+
+  enqueue (type, message, callback) {
+    callback = callback || noop
+
+    message = Object.assign({}, message)
+    message.type = type
+    message.context = Object.assign({
+      library: {
+        name: 'analytics-node',
+        version
+      }
+    }, message.context)
+
+    message._metadata = Object.assign({
+      nodeVersion: process.versions.node
+    }, message._metadata)
+
+    if (!message.timestamp) {
+      message.timestamp = new Date()
+    }
+
+    if (!message.messageId) {
+      message.messageId = `node-${uid(32)}`
+    }
+
+    debug('%s: %o', type, message)
+
+    this.queue.push({ message, callback })
+
+    if (this.queue.length >= this.flushAt) {
+      this.flush()
+    }
+
+    if (this.flushAfter && !this.timer) {
+      this.timer = setTimeout(this.flush.bind(this), this.flushAfter)
+    }
+  }
+
+  /**
+   * Flush the current queue
+   *
+   * @param {Function} [callback] (optional)
+   * @return {Analytics}
+   */
+
+  flush (callback) {
+    callback = callback || noop
+
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+
+    if (!this.queue.length) {
+      return setImmediate(callback)
+    }
+
+    const items = this.queue.splice(0, this.flushAt)
+    const callbacks = items.map(item => item.callback)
+    const messages = items.map(item => item.message)
+
+    const data = {
+      batch: messages,
+      timestamp: new Date(),
+      sentAt: new Date()
+    }
+
+    debug('flush: %o', data)
+
+    request
+      .post(`${this.host}/v1/batch`)
+      .auth(this.writeKey, '')
+      .retry(3)
+      .send(data)
+      .end((err, res) => {
+        err = err || error(res)
+
+        callbacks.forEach(callback => callback(err))
+        callback(err, data)
+
+        debug('flushed: %o', data)
+      })
+  }
+}
+
+module.exports = Analytics

--- a/package.json
+++ b/package.json
@@ -16,11 +16,9 @@
   },
   "dependencies": {
     "@segment/loosely-validate-event": "^1.1.2",
-    "clone": "^2.1.1",
     "commander": "^2.9.0",
     "crypto-token": "^1.0.1",
     "debug": "^2.6.2",
-    "lodash": "^4.17.4",
     "remove-trailing-slash": "^0.1.0",
     "superagent": "^3.5.0"
   },
@@ -35,7 +33,7 @@
     "standard": "^9.0.1"
   },
   "engines": {
-    "node": ">= 0.12.x"
+    "node": ">= 4"
   },
   "scripts": {
     "test": "make test"

--- a/test/index.js
+++ b/test/index.js
@@ -40,10 +40,6 @@ test('require a write key', t => {
   t.throws(() => new Analytics(), 'You must pass your Segment project\'s write key.')
 })
 
-test('don\'t require the new keyword', t => {
-  t.notThrows(() => Analytics('key'))
-})
-
 test('create a queue', t => {
   const client = createClient()
 


### PR DESCRIPTION
This PR brings a breaking change - inability to create an instance without a `new` keyword, which is a JavaScript limitation.

Also removes the dependency on `lodash/extend` and `clone`, since those can be replaced with `Object.assign()`.

Tests are failing, because I haven't modified them for the above mentioned change. I would like to merge #108 first, to avoid a merge conflict.