### PR TITLE
Flush on first message

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ class Analytics {
     this.host = removeSlash(options.host || 'https://api.segment.io')
     this.flushAt = Math.max(options.flushAt, 1) || 20
     this.flushInterval = options.flushInterval || 10000
+    this.flushed = false
   }
 
   /**
@@ -174,6 +175,12 @@ class Analytics {
     debug('%s: %o', type, message)
 
     this.queue.push({ message, callback })
+
+    if (!this.flushed) {
+      this.flushed = true
+      this.flush()
+      return
+    }
 
     if (this.queue.length >= this.flushAt) {
       this.flush()

--- a/test.js
+++ b/test.js
@@ -26,6 +26,7 @@ const createClient = options => {
 
   const client = new Analytics('key', options)
   client.flush = pify(client.flush.bind(client))
+  client.flushed = true
 
   return client
 }
@@ -125,6 +126,21 @@ test('enqueue - don\'t modify the original message', t => {
   client.enqueue('type', message)
 
   t.deepEqual(message, { event: 'test' })
+})
+
+test('enqueue - flush on first message', t => {
+  const client = createClient({ flushAt: 2 })
+  client.flushed = false
+  spy(client, 'flush')
+
+  client.enqueue('type', {})
+  t.true(client.flush.calledOnce)
+
+  client.enqueue('type', {})
+  t.true(client.flush.calledOnce)
+
+  client.enqueue('type', {})
+  t.true(client.flush.calledTwice)
 })
 
 test('enqueue - flush the queue if it hits the max length', t => {


### PR DESCRIPTION
Refs https://github.com/segmentio/analytics-node/issues/53.

As correctly pointed out in https://github.com/segmentio/analytics-node/issues/53, the client should flush right after it receives a first message. This PR implements that behavior.