### PR TITLE
Flush after identify or group

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,6 +182,11 @@ class Analytics {
       return
     }
 
+    if (type === 'identify' || type === 'group') {
+      this.flush()
+      return
+    }
+
     if (this.queue.length >= this.flushAt) {
       this.flush()
     }

--- a/test.js
+++ b/test.js
@@ -143,6 +143,23 @@ test('enqueue - flush on first message', t => {
   t.true(client.flush.calledTwice)
 })
 
+test('enqueue - flush on identify or group message', t => {
+  const client = createClient({ flushAt: 10 })
+  spy(client, 'flush')
+
+  client.enqueue('identify', {})
+  t.true(client.flush.calledOnce)
+
+  client.enqueue('group', {})
+  t.true(client.flush.calledTwice)
+
+  client.enqueue('track', {})
+  client.enqueue('page', {})
+  client.enqueue('screen', {})
+  client.enqueue('alias', {})
+  t.true(client.flush.calledTwice)
+})
+
 test('enqueue - flush the queue if it hits the max length', t => {
   const client = createClient({
     flushAt: 1,


### PR DESCRIPTION
Fixes https://github.com/segmentio/analytics-node/issues/95.

As discussed, flushing after `identify()` is necessary in order to preserve traits for future messages. When looking through the docs, I saw that `group()` also has traits, so I added it too.

One question though, should we also flush after `alias()`?