### PR TITLE
Add `enable` option to disable flushing

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ class Analytics {
     this.flushAt = Math.max(options.flushAt, 1) || 20
     this.flushInterval = options.flushInterval || 10000
     this.flushed = false
+    this.enabled = typeof options.enable === 'boolean' ? options.enable : true
 
     retries(axios, options.retryCount || 3)
   }
@@ -138,6 +139,10 @@ class Analytics {
   enqueue (type, message, callback) {
     callback = callback || noop
 
+    if (!this.enabled) {
+      return setImmediate(callback)
+    }
+
     message = Object.assign({}, message)
     message.type = type
     message.context = Object.assign({
@@ -187,6 +192,10 @@ class Analytics {
 
   flush (callback) {
     callback = callback || noop
+
+    if (!this.enabled) {
+      return setImmediate(callback)
+    }
 
     if (this.timer) {
       clearTimeout(this.timer)

--- a/test.js
+++ b/test.js
@@ -206,6 +206,18 @@ test('enqueue - extend context', t => {
   t.deepEqual(actualContext, expectedContext)
 })
 
+test('enqueue - skip when client is disabled', async t => {
+  const client = createClient({ enable: false })
+  stub(client, 'flush')
+
+  const callback = spy()
+  client.enqueue('type', {}, callback)
+  await delay(5)
+
+  t.true(callback.calledOnce)
+  t.false(client.flush.called)
+})
+
 test('flush - don\'t fail when queue is empty', async t => {
   const client = createClient()
 
@@ -270,6 +282,23 @@ test('flush - time out if configured', async t => {
   ]
 
   await t.throws(client.flush(), 'timeout of 500ms exceeded')
+})
+
+test('flush - skip when client is disabled', async t => {
+  const client = createClient({ enable: false })
+  const callback = spy()
+
+  client.queue = [
+    {
+      message: 'test',
+      callback
+    }
+  ]
+
+  const data = await client.flush()
+
+  t.is(data, undefined)
+  t.false(callback.called)
 })
 
 test('identify - enqueue a message', t => {


### PR DESCRIPTION
Fixes https://github.com/segmentio/analytics-node/issues/116.

Allows to silently skip sending of messages, which is useful in tests and in development. Example usage:

```js
const client = new Client('write key', {
  enable: process.env.NODE_ENV === 'production'
})
```