### PR TITLE
Allow configuring retries and timeout.

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,8 @@ class Analytics {
     this.queue = []
     this.writeKey = writeKey
     this.host = removeSlash(options.host || 'https://api.segment.io')
+    this.retryCount = options.retryCount || 3
+    this.timeout = options.timeout || false
     this.flushAt = Math.max(options.flushAt, 1) || 20
     this.flushInterval = options.flushInterval || 10000
     this.flushed = false
@@ -225,7 +227,8 @@ class Analytics {
     request
       .post(`${this.host}/v1/batch`)
       .auth(this.writeKey, '')
-      .retry(3)
+      .timeout(this.timeout)
+      .retry(this.retryCount)
       .send(data)
       .end((err, res) => {
         err = err || error(res)

--- a/test.js
+++ b/test.js
@@ -43,6 +43,10 @@ test.before.cb(t => {
         })
       }
 
+      if (batch[0] === 'timeout') {
+        return setTimeout(() => res.end(), 5000)
+      }
+
       res.json({})
     })
     .listen(port, t.end)
@@ -244,6 +248,20 @@ test('flush - respond with an error', async t => {
   ]
 
   await t.throws(client.flush(), 'Bad Request')
+})
+
+test('flush - time out if configured', async t => {
+  const client = createClient({timeout: 500})
+  const callback = spy()
+
+  client.queue = [
+    {
+      message: 'timeout',
+      callback
+    }
+  ]
+
+  await t.throws(client.flush(), 'Timeout of 500ms exceeded')
 })
 
 test('identify - enqueue a message', t => {


### PR DESCRIPTION
- timeout was not enabled nor configurable previously
- retries were hardcoded to `3` and not configurable

Fixes https://github.com/segmentio/analytics-node/issues/119.

I looked into writing tests, but you've got the [mock server set up in a `before`](https://github.com/segmentio/analytics-node/blob/4290503572a7c9661661dbcafef75b573cdbda0b/test.js#L34-L49) so I would need to refactor the tests to allow a test or two to configure the server to conditionally fail with a retryable error or not respond. If the lack of tests is a blocker, I can give it a try.

Thanks!