### PR TITLE
add `nsprc` to ignore superagent zip bomb vulnerability

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,3 @@
+{
+  "exceptions": ["https://nodesecurity.io/advisories/479"]
+}


### PR DESCRIPTION
Since we're already vulnerable, ignoring this for now while we merge a few PRs and create a new release won't _hurt_ anything. We should obviously address the vulnerability correctly (rather than ignoring it), and finally remove our dependency on superagent (see #124).