### PR TITLE
add write key to request

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,6 +219,9 @@ class Analytics {
     const req = {
       method: 'POST',
       url: `${this.host}/v1/batch`,
+      auth: {
+        username: this.writeKey
+      },
       data
     }
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "ava": "^0.21.0",
+    "basic-auth": "^2.0.0",
     "body-parser": "^1.17.1",
     "delay": "^2.0.0",
     "express": "^4.15.2",

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ import {spy, stub} from 'sinon'
 import bodyParser from 'body-parser'
 import express from 'express'
 import delay from 'delay'
+import auth from 'basic-auth'
 import pify from 'pify'
 import test from 'ava'
 import Analytics from '.'
@@ -36,6 +37,13 @@ test.before.cb(t => {
     .use(bodyParser.json())
     .post('/v1/batch', (req, res) => {
       const batch = req.body.batch
+
+      const { name: writeKey } = auth(req)
+      if (!writeKey) {
+        return res.status(400).json({
+          error: { message: 'missing write key' }
+        })
+      }
 
       if (batch[0] === 'error') {
         return res.status(400).json({


### PR DESCRIPTION
When moving to Axios, I didn't add the write key to the requests. Our
tests didn't catch this, so I figured we were safe to release a new
version.

This patch corrects that, and ensures this will never happen again by
updating the tests.

Closes #127