### PR TITLE
add useragent

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,7 +222,10 @@ class Analytics {
       auth: {
         username: this.writeKey
       },
-      data
+      data,
+      headers: {
+        'user-agent': `analytics-node@${version}`
+      }
     }
 
     if (this.timeout) {

--- a/index.js
+++ b/index.js
@@ -224,7 +224,7 @@ class Analytics {
       },
       data,
       headers: {
-        'user-agent': `analytics-node@${version}`
+        'user-agent': `analytics-node ${version}`
       }
     }
 

--- a/test.js
+++ b/test.js
@@ -45,6 +45,13 @@ test.before.cb(t => {
         })
       }
 
+      const ua = req.headers['user-agent']
+      if (ua !== `analytics-node@${version}`) {
+        return res.status(400).json({
+          error: { message: 'invalid user-agent' }
+        })
+      }
+
       if (batch[0] === 'error') {
         return res.status(400).json({
           error: { message: 'error' }

--- a/test.js
+++ b/test.js
@@ -46,7 +46,7 @@ test.before.cb(t => {
       }
 
       const ua = req.headers['user-agent']
-      if (ua !== `analytics-node@${version}`) {
+      if (ua !== `analytics-node ${version}`) {
         return res.status(400).json({
           error: { message: 'invalid user-agent' }
         })


### PR DESCRIPTION
This patch adds the `User-Agent` header to all requests made to the Segment API. In the event we need to track how many requests are coming in from a specific version of the library in the future, we can check CDN logs/stats for this header.