### PR TITLE
Remove RUN_E2E_TESTS from Circle config.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,6 @@
 machine:
   node:
     version: 6
-  environment:
-    RUN_E2E_TESTS: true
 
 dependencies:
   pre:


### PR DESCRIPTION
Instead of setting this up via the config file, we'll do this as an encrypted variable via the UI https://circleci.com/gh/segmentio/analytics-node/edit#env-vars.

Otherwise the `RUN_E2E_TESTS` variable is true for contributors, but their builds won't have the `RUNSCOPE_TOKEN` which is encrypted and not available to them. This causes contributor PRs to fail as the test suite tries to run the end to end tests without the appropriate tokens.