### PR TITLE
Replace crypto-token with uuid.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ const validate = require('@segment/loosely-validate-event')
 const axios = require('axios')
 const axiosRetry = require('axios-retry')
 const ms = require('ms')
-const uid = require('crypto-token')
+const uuid = require('uuid/v4')
+const md5 = require('md5')
 const version = require('./package.json').version
 const isString = require('lodash.isstring')
 
@@ -159,7 +160,11 @@ class Analytics {
     }
 
     if (!message.messageId) {
-      message.messageId = `node-${uid(32)}`
+      // We md5 the messaage to add more randomness. This is primarily meant
+      // for use in the browser where the uuid package falls back to Math.random()
+      // which is not a great source of randomness.
+      // Borrowed from analytics.js (https://github.com/segment-integrations/analytics.js-integration-segmentio/blob/a20d2a2d222aeb3ab2a8c7e72280f1df2618440e/lib/index.js#L255-L256).
+      message.messageId = `node-${md5(JSON.stringify(message))}-${uuid()}`
     }
 
     // Historically this library has accepted strings and numbers as IDs.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "size-limit": [
     {
-      "limit": "150 KB",
+      "limit": "25 KB",
       "path": "index.js"
     }
   ],
@@ -47,7 +47,8 @@
     "axios": "^0.17.1",
     "axios-retry": "^3.0.1",
     "commander": "^2.9.0",
-    "crypto-token": "^1.0.1",
+    "uuid": "^3.2.1",
+    "md5": "^2.2.1",
     "lodash.isstring": "^4.0.1",
     "ms": "^2.0.0",
     "remove-trailing-slash": "^0.1.0"

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ import pify from 'pify'
 import test from 'ava'
 import axios from 'axios'
 import retries from 'axios-retry'
-import uid from 'crypto-token'
+import uuid from 'uuid/v4'
 import Analytics from '.'
 import {version} from './package'
 
@@ -528,7 +528,7 @@ if (RUN_E2E_TESTS) {
   // sent by this library.
   // This is described in more detail at https://paper.dropbox.com/doc/analytics-node-E2E-Test-9oavh3DFcFBXuqCJBe1o9.
   test('end to end test', async t => {
-    const id = uid(16)
+    const id = uuid()
 
     // Segment Write Key for https://segment.com/segment-libraries/sources/analytics_node_e2e_test/overview.
     // This source is configured to send events to a Runscope bucket used by this test.


### PR DESCRIPTION
Both use the node crypto package on Node apps so there shouldn't be a meaningful difference here.

The differences come in the browser. crypto-token works in the browser by polyfilling the crypto package. node-uuid works by using the browser crypto apis if available, otherwise falling back to Math.random() (https://github.com/kelektiv/node-uuid/blob/master/lib/rng-browser.js).

Because of polyfilling on the browser, crypto-token contributes 90kb to our library in the browser which is rougly 80% of the library size on the browser (the rest of the library is only 20kb). node-uuid only adds 1kb (though I believe this comes at the cost of generating slightly less random messageIds on the browser). I don't think the extra weight is worth the cost, especially as we're not using this in a critical security context.

One thing we now do to increase randomness in the browser is includes a hash of the contents of the message as well like we do in a.js (https://github.com/segment-integrations/analytics.js-integration-segmentio/blob/master/lib/index.js#L256). On a side note, analytics.js also uses the uuid package.

Before:

  Package size: 107.79 KB
  With all dependencies, minified and gzipped

After:

  Package size: 13.79 KB
  With all dependencies, minified and gzipped

Because of the significant reduction in size, I also updated the size limit to be 25kb instead of 150kb.