### PR TITLE
Need to Delay Retry

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,10 @@ class Analytics {
 
     axiosRetry(axios, {
       retries: options.retryCount || 3,
-      retryCondition: this._isErrorRetryable
+      retryCondition: this._isErrorRetryable,
+      retryDelay: function(retryCount) {
+        return options.retryDelay || 500;
+      }
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -49,9 +49,7 @@ class Analytics {
     axiosRetry(axios, {
       retries: options.retryCount || 3,
       retryCondition: this._isErrorRetryable,
-      retryDelay: function (retryCount) {
-        return options.retryDelay || 500
-      }
+      retryDelay: axiosRetry.exponentialDelay
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -49,8 +49,8 @@ class Analytics {
     axiosRetry(axios, {
       retries: options.retryCount || 3,
       retryCondition: this._isErrorRetryable,
-      retryDelay: function(retryCount) {
-        return options.retryDelay || 500;
+      retryDelay: function (retryCount) {
+        return options.retryDelay || 500
       }
     })
   }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "lodash.isstring": "^4.0.1",
     "md5": "^2.2.1",
     "ms": "^2.0.0",
-    "prettyjson": "^1.2.1",
     "remove-trailing-slash": "^0.1.0",
     "uuid": "^3.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -45,13 +45,14 @@
   "dependencies": {
     "@segment/loosely-validate-event": "^2.0.0",
     "axios": "^0.17.1",
-    "axios-retry": "^3.0.1",
+    "axios-retry": "^3.0.2",
     "commander": "^2.9.0",
-    "uuid": "^3.2.1",
-    "md5": "^2.2.1",
     "lodash.isstring": "^4.0.1",
+    "md5": "^2.2.1",
     "ms": "^2.0.0",
-    "remove-trailing-slash": "^0.1.0"
+    "prettyjson": "^1.2.1",
+    "remove-trailing-slash": "^0.1.0",
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
     "ava": "^0.25.0",


### PR DESCRIPTION
Sometimes we need to delay retry to avoid high CPU consumes during retry, especially when we set `retryCount` to big number.