### PR TITLE
add standardized makefile

### DIFF
--- a/.buildscript/bootstrap.sh
+++ b/.buildscript/bootstrap.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if ! which brew >/dev/null; then
+  echo "homebrew is not available. Install it from http://brew.sh"
+  exit 1
+else
+  echo "homebrew already installed"
+fi
+
+if ! which node >/dev/null; then
+  echo "installing node..."
+  brew install node
+else
+  echo "node already installed"
+fi
+
+if ! which yarn >/dev/null; then
+  echo "installing yarn..."
+  brew install yarn
+else
+  echo "yarn already installed"
+fi
+
+echo "all dependencies installed."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+bootstrap:
+	.buildscript/bootstrap.sh
+
+# use yarn scripts for the rest
+%:
+	@yarn $@
+
+.PHONY: bootstrap

--- a/package.json
+++ b/package.json
@@ -22,12 +22,14 @@
     }
   ],
   "scripts": {
+    "dependencies": "yarn",
     "size": "size-limit",
     "test": "standard && nyc ava",
     "prepublish": "npm run check-deps",
     "check-deps": "nsp check",
     "report-coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",
-    "np": "np --no-publish"
+    "np": "np --no-publish",
+    "release": "yarn run np"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
Instead of defining targets here, we delegate to Yarn for most targets.