### PR TITLE
Use library-e2e-tester 

### DIFF
--- a/.buildscript/e2e.sh
+++ b/.buildscript/e2e.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+if [ "$RUN_E2E_TESTS" != "true" ]; then
+  echo "Skipping end to end tests."
+else
+  echo "Running end to end tests..."
+  wget https://github.com/segmentio/library-e2e-tester/releases/download/0.2.1/tester_linux_amd64 -O tester
+  chmod +x tester
+  ./tester -path='./cli.js'
+  echo "End to end tests completed!"
+fi

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "dependencies": "yarn",
     "size": "size-limit",
-    "test": "standard && nyc ava",
+    "test": "standard && nyc ava && .buildscript/e2e.sh",
     "prepublish": "npm run check-deps",
     "check-deps": "nsp check",
     "report-coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",


### PR DESCRIPTION
Instead of our handrolled end to end testing code, use library-e2e-tester which is more consistent and supports more message types.

Requires refactoring the existing cli.js file to match the library-e2e-tester interface