### PR TITLE
[SCH-1270] User-supplied context.library overwrites name and version

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,14 +166,14 @@ class Analytics {
       return setImmediate(callback)
     }
 
-    message = Object.assign({}, message)
+    message = Object.assign({
+      context: {}
+    }, message)
     message.type = type
-    message.context = Object.assign({
-      library: {
-        name: 'analytics-node',
-        version
-      }
-    }, message.context)
+    message.context.library = Object.assign({
+      name: 'analytics-node',
+      version
+    }, message.context.library)
 
     message._metadata = Object.assign({
       nodeVersion: process.versions.node

--- a/test.js
+++ b/test.js
@@ -138,6 +138,28 @@ test('enqueue - add a message to the queue', t => {
   })
 })
 
+// This functionality is utilized by Segment Typewriter.
+test('enqueue a message with library context fields', t => {
+  const client = createClient()
+
+  client.enqueue('type', {
+    context: {
+      library: {
+        'foo': 'bar'
+      }
+    }
+  })
+
+  const item = client.queue.pop()
+
+  t.deepEqual(item.message.context, {
+    library: {
+      ...context.library,
+      'foo': 'bar'
+    }
+  })
+})
+
 test('enqueue - stringify userId', t => {
   const client = createClient()
 


### PR DESCRIPTION
We set extra context fields using [Typewriter](https://github.com/segmentio/typewriter) under `context.library.typewriter`, but this overwrites the `library` fields set by `analytics-node`:

```
{
  "context": {
    ...
    "library": {
      "name": "unknown",
      "typewriter": {
        "name": "gen-js",
        "version": "3.2.2"
      },
      "version": "unknown"
    }
  },
  ...
}
```
