### PR TITLE
ci: fix publish step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
             - test
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)*(-.+)?/
+              only: /v[0-9]+(\.[0-9]+)*(-.+)?/
             branches:
               ignore: /.*/
   static_analysis:


### PR DESCRIPTION
Previously the publish step would only run on tags such as `3.4.0-beta`, however, with `np` we name tags with a `v` prefix (e.g. `v3.4.0-beta`), causing the publish job step to never run.

This updates the tag regex filter to allow the publish step to run on tags like `v3.4.0-beta`.