### PR TITLE
add npm context to publish step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,7 @@ jobs:
       - run: yarn run snyk test --severity-threshold=high
       - run: yarn run snyk monitor
   publish:
+    context: npm
     docker:
       - image: circleci/node:10-browsers
     steps:


### PR DESCRIPTION
we moved some tokens around, and the NPM_AUTH variable is available via the npm context in Circle CI.