### PR TITLE
fix context declaration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ workflows:
       - test-node10
       - test-node12
   test_and_publish:
+    context: npm
     jobs:
       - test:
           filters:
@@ -105,7 +106,6 @@ jobs:
       - run: yarn run snyk test --severity-threshold=high
       - run: yarn run snyk monitor
   publish:
-    context: npm
     docker:
       - image: circleci/node:10-browsers
     steps:


### PR DESCRIPTION
context is declared on the workflow, rather than the job.

```
> circleci config validate -c .circleci/config.yml

.circleci/config.yml is valid
```