### PR TITLE
attach `npm` context to publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,13 @@ workflows:
       - test-node10
       - test-node12
   test_and_publish:
-    context: npm
     jobs:
       - test:
           filters:
             tags:
               only: /.*/
       - publish:
+          context: npm
           requires:
             - test
           filters:


### PR DESCRIPTION
As Nick pointed out in https://github.com/segmentio/analytics-node/pull/216#discussion_r295932570, this should be on the specific step in the job.

```
> circleci config validate -c .circleci/config.yml
Config file at .circleci/config.yml is valid.
```