### PR TITLE
Fix for infinite axios-retry on 5xx responses and axios client option leakage

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,8 +45,8 @@ class Analytics {
       enumerable: true,
       value: typeof options.enable === 'boolean' ? options.enable : true
     })
-
-    axiosRetry(axios, {
+    this.axiosClient = axios.create()
+    axiosRetry(this.axiosClient, {
       retries: options.retryCount || 3,
       retryCondition: this._isErrorRetryable,
       retryDelay: axiosRetry.exponentialDelay
@@ -279,7 +279,7 @@ class Analytics {
       req.timeout = typeof this.timeout === 'string' ? ms(this.timeout) : this.timeout
     }
 
-    axios(req)
+    this.axiosClient(req)
       .then(() => done())
       .catch(err => {
         if (err.response) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   ],
   "dependencies": {
     "@segment/loosely-validate-event": "^2.0.0",
-    "axios": "^0.19.0",
+    "axios": "^0.19.2",
     "axios-retry": "^3.0.2",
     "lodash.isstring": "^4.0.1",
     "md5": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "circle-lint": ".buildscript/circle.sh",
     "dependencies": "yarn",
     "size": "size-limit",
-    "test": "standard && nyc ava && .buildscript/e2e.sh",
+    "test": "standard && nyc ava --timeout=20s&& .buildscript/e2e.sh",
     "report-coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",
     "np": "np --no-publish",
     "release": "yarn run np"

--- a/test.js
+++ b/test.js
@@ -72,6 +72,12 @@ test.before.cb(t => {
         })
       }
 
+      if (batch[0] === 'axios-retry-forever') {
+        return res.status(503).json({
+          error: { message: 'Service Unavailable' }
+        })
+      }
+
       res.json({})
     })
     .listen(port, t.end)
@@ -584,6 +590,20 @@ test('ensure that failed requests are retried', async t => {
   ]
 
   await t.notThrows(client.flush())
+})
+
+test('ensure that failed requests are not retried forever', async t => {
+  const client = createClient()
+  const callback = spy()
+
+  client.queue = [
+    {
+      message: 'axios-retry-forever',
+      callback
+    }
+  ]
+
+  await t.throws(client.flush())
 })
 
 test('ensure other axios clients are not impacted by axios-retry', async t => {

--- a/test.js
+++ b/test.js
@@ -36,7 +36,6 @@ const createClient = options => {
 
 test.before.cb(t => {
   let count = 0
-  
   express()
     .use(bodyParser.json())
     .post('/v1/batch', (req, res) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -829,13 +829,12 @@ axios-retry@^3.0.2:
   dependencies:
     is-retry-allowed "^1.1.0"
 
-axios@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
-  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
   dependencies:
     follow-redirects "1.5.10"
-    is-buffer "^2.0.2"
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -4217,11 +4216,6 @@ is-buffer@^1.0.2, is-buffer@^1.1.5, is-buffer@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
-
-is-buffer@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
-  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
 is-builtin-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This merge seeks to address two issues:

1. Fix the infinite retry bug associated with axios 0.19.0
2. Prevent axios-retry options from leaking into other codebases that are using axios

To address the first concern I've updated the current version of axios to 0.19.2 which contains the necessary fixes for avoiding infinite retries within axios when the HTTP response is within the 5xx range. 

As per the second concern, I've configured the Analytics class to instead use it's own axios client, thereby preventing client options from leaking into other axios instances. 

Unit tests have been added to validate that the retries are in fact working and that option leakage is no longer occuring.