### PR TITLE
Flush when approaching the limit instead of surpassing the limit

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ class Analytics {
     this.axiosInstance = axiosInstance
     this.timeout = options.timeout || false
     this.flushAt = Math.max(options.flushAt, 1) || 20
-    this.maxQueueSize = options.maxQueueSize || 1024 * 500 // defaults to 500kb
+    this.maxQueueSize = options.maxQueueSize || 1024 * 450 // 500kb is the API limit, if we approach the limit i.e., 450kb, we'll flush
     this.flushInterval = options.flushInterval || 10000
     this.flushed = false
     Object.defineProperty(this, 'enable', {


### PR DESCRIPTION
Updating the queue size limit to flush when approaching instead of surpassing. 