### PR TITLE
Solving race condition between flushes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,9 +79,9 @@ class Analytics {
    * @return {Analytics}
    */
 
-  identify (message, callback) {
+  async identify (message, callback) {
     this._validate(message, 'identify')
-    this.enqueue('identify', message, callback)
+    await this.enqueue('identify', message, callback)
     return this
   }
 
@@ -93,9 +93,9 @@ class Analytics {
    * @return {Analytics}
    */
 
-  group (message, callback) {
+  async group (message, callback) {
     this._validate(message, 'group')
-    this.enqueue('group', message, callback)
+    await this.enqueue('group', message, callback)
     return this
   }
 
@@ -107,9 +107,9 @@ class Analytics {
    * @return {Analytics}
    */
 
-  track (message, callback) {
+  async track (message, callback) {
     this._validate(message, 'track')
-    this.enqueue('track', message, callback)
+    await this.enqueue('track', message, callback)
     return this
   }
 
@@ -121,9 +121,9 @@ class Analytics {
    * @return {Analytics}
    */
 
-  page (message, callback) {
+  async page (message, callback) {
     this._validate(message, 'page')
-    this.enqueue('page', message, callback)
+    await this.enqueue('page', message, callback)
     return this
   }
 
@@ -135,9 +135,9 @@ class Analytics {
    * @return {Analytics}
    */
 
-  screen (message, callback) {
+  async screen (message, callback) {
     this._validate(message, 'screen')
-    this.enqueue('screen', message, callback)
+    await this.enqueue('screen', message, callback)
     return this
   }
 
@@ -149,9 +149,9 @@ class Analytics {
    * @return {Analytics}
    */
 
-  alias (message, callback) {
+  async alias (message, callback) {
     this._validate(message, 'alias')
-    this.enqueue('alias', message, callback)
+    await this.enqueue('alias', message, callback)
     return this
   }
 
@@ -211,19 +211,19 @@ class Analytics {
 
     if (!this.flushed) {
       this.flushed = true
-      this.flush(callback)
+      await this.flush()
       return
     }
 
     const hasReachedFlushAt = this.queue.length >= this.flushAt
     const hasReachedQueueSize = this.queue.reduce((acc, item) => acc + JSON.stringify(item).length, 0) >= this.maxQueueSize
     if (hasReachedFlushAt || hasReachedQueueSize) {
-      this.flush(callback)
+      await this.flush()
       return
     }
 
     if (this.flushInterval && !this.timer) {
-      this.timer = setTimeout(this.flush.bind(this, callback), this.flushInterval)
+      this.timer = setTimeout(await this.flush.bind(this), this.flushInterval)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ class Analytics {
    * @api private
    */
 
-  enqueue (type, message, callback) {
+  async enqueue (type, message, callback) {
     callback = callback || noop
 
     if (!this.enable) {

--- a/test.js
+++ b/test.js
@@ -249,7 +249,7 @@ test('enqueue - flush after a period of time', async t => {
   const client = createClient({ flushInterval: 10 })
   stub(client, 'flush')
 
-  client.enqueue('type', {})
+  await client.enqueue('type', {})
 
   t.false(client.flush.called)
   await delay(20)
@@ -436,12 +436,17 @@ test('identify - enqueue a message', t => {
   t.deepEqual(client.enqueue.firstCall.args, ['identify', message, noop])
 })
 
-test('identify - require a userId or anonymousId', t => {
+test('identify - require a userId or anonymousId', async t => {
   const client = createClient()
   stub(client, 'enqueue')
 
-  t.throws(() => client.identify(), 'You must pass a message object.')
-  t.throws(() => client.identify({}), 'You must pass either an "anonymousId" or a "userId".')
+  await client.identify().catch((err) => {
+    t.deepEqual(err.message, 'You must pass a message object.')
+  })
+  await client.identify({}).catch((err) => {
+    t.deepEqual(err.message, 'You must pass either an "anonymousId" or a "userId".')
+  })
+
   t.notThrows(() => client.identify({ userId: 'id' }))
   t.notThrows(() => client.identify({ anonymousId: 'id' }))
 })
@@ -461,14 +466,23 @@ test('group - enqueue a message', t => {
   t.deepEqual(client.enqueue.firstCall.args, ['group', message, noop])
 })
 
-test('group - require a groupId and either userId or anonymousId', t => {
+test('group - require a groupId and either userId or anonymousId', async t => {
   const client = createClient()
   stub(client, 'enqueue')
 
-  t.throws(() => client.group(), 'You must pass a message object.')
-  t.throws(() => client.group({}), 'You must pass either an "anonymousId" or a "userId".')
-  t.throws(() => client.group({ userId: 'id' }), 'You must pass a "groupId".')
-  t.throws(() => client.group({ anonymousId: 'id' }), 'You must pass a "groupId".')
+  await client.group().catch((err) => {
+    t.deepEqual(err.message, 'You must pass a message object.')
+  })
+  await client.group({}).catch((err) => {
+    t.deepEqual(err.message, 'You must pass either an "anonymousId" or a "userId".')
+  })
+  await client.group({ userId: 'id' }).catch((err) => {
+    t.deepEqual(err.message, 'You must pass a "groupId".')
+  })
+  await client.group({ anonymousId: 'id' }).catch((err) => {
+    t.deepEqual(err.message, 'You must pass a "groupId".')
+  })
+
   t.notThrows(() => {
     client.group({
       groupId: 'id',
@@ -499,14 +513,23 @@ test('track - enqueue a message', t => {
   t.deepEqual(client.enqueue.firstCall.args, ['track', message, noop])
 })
 
-test('track - require event and either userId or anonymousId', t => {
+test('track - require event and either userId or anonymousId', async t => {
   const client = createClient()
   stub(client, 'enqueue')
 
-  t.throws(() => client.track(), 'You must pass a message object.')
-  t.throws(() => client.track({}), 'You must pass either an "anonymousId" or a "userId".')
-  t.throws(() => client.track({ userId: 'id' }), 'You must pass an "event".')
-  t.throws(() => client.track({ anonymousId: 'id' }), 'You must pass an "event".')
+  await client.track().catch((err) => {
+    t.deepEqual(err.message, 'You must pass a message object.')
+  })
+  await client.track({}).catch((err) => {
+    t.deepEqual(err.message, 'You must pass either an "anonymousId" or a "userId".')
+  })
+  await client.track({ userId: 'id' }).catch((err) => {
+    t.deepEqual(err.message, 'You must pass an "event".')
+  })
+  await client.track({ anonymousId: 'id' }).catch((err) => {
+    t.deepEqual(err.message, 'You must pass an "event".')
+  })
+
   t.notThrows(() => {
     client.track({
       userId: 'id',
@@ -533,12 +556,17 @@ test('page - enqueue a message', t => {
   t.deepEqual(client.enqueue.firstCall.args, ['page', message, noop])
 })
 
-test('page - require either userId or anonymousId', t => {
+test('page - require either userId or anonymousId', async t => {
   const client = createClient()
   stub(client, 'enqueue')
 
-  t.throws(() => client.page(), 'You must pass a message object.')
-  t.throws(() => client.page({}), 'You must pass either an "anonymousId" or a "userId".')
+  await client.page().catch((err) => {
+    t.deepEqual(err.message, 'You must pass a message object.')
+  })
+  await client.page({}).catch((err) => {
+    t.deepEqual(err.message, 'You must pass either an "anonymousId" or a "userId".')
+  })
+
   t.notThrows(() => client.page({ userId: 'id' }))
   t.notThrows(() => client.page({ anonymousId: 'id' }))
 })
@@ -554,12 +582,17 @@ test('screen - enqueue a message', t => {
   t.deepEqual(client.enqueue.firstCall.args, ['screen', message, noop])
 })
 
-test('screen - require either userId or anonymousId', t => {
+test('screen - require either userId or anonymousId', async t => {
   const client = createClient()
   stub(client, 'enqueue')
 
-  t.throws(() => client.screen(), 'You must pass a message object.')
-  t.throws(() => client.screen({}), 'You must pass either an "anonymousId" or a "userId".')
+  await client.screen().catch((err) => {
+    t.deepEqual(err.message, 'You must pass a message object.')
+  })
+  await client.screen({}).catch((err) => {
+    t.deepEqual(err.message, 'You must pass either an "anonymousId" or a "userId".')
+  })
+
   t.notThrows(() => client.screen({ userId: 'id' }))
   t.notThrows(() => client.screen({ anonymousId: 'id' }))
 })
@@ -579,13 +612,20 @@ test('alias - enqueue a message', t => {
   t.deepEqual(client.enqueue.firstCall.args, ['alias', message, noop])
 })
 
-test('alias - require previousId and userId', t => {
+test('alias - require previousId and userId', async t => {
   const client = createClient()
   stub(client, 'enqueue')
 
-  t.throws(() => client.alias(), 'You must pass a message object.')
-  t.throws(() => client.alias({}), 'You must pass a "userId".')
-  t.throws(() => client.alias({ userId: 'id' }), 'You must pass a "previousId".')
+  await client.alias().catch((err) => {
+    t.deepEqual(err.message, 'You must pass a message object.')
+  })
+  await client.alias({}).catch((err) => {
+    t.deepEqual(err.message, 'You must pass a "userId".')
+  })
+  await client.alias({ userId: 'id' }).catch((err) => {
+    t.deepEqual(err.message, 'You must pass a "previousId".')
+  })
+
   t.notThrows(() => {
     client.alias({
       userId: 'id',
@@ -611,7 +651,7 @@ test('isErrorRetryable', t => {
   t.false(client._isErrorRetryable({ response: { status: 200 } }))
 })
 
-test('dont allow messages > 32kb', t => {
+test('dont allow messages > 32kb', async t => {
   const client = createClient()
 
   const event = {
@@ -623,8 +663,8 @@ test('dont allow messages > 32kb', t => {
     event.properties[i] = 'a'
   }
 
-  t.throws(() => {
-    client.track(event, noop)
+  await client.track(event, noop).catch((err) => {
+    t.deepEqual(err.message, 'Your message must be < 32kb.')
   })
 })
 

--- a/test.js
+++ b/test.js
@@ -274,11 +274,11 @@ test('enqueue - prevent flushing through time interval when already flushed by f
   client.flushed = false
   spy(client, 'flush')
 
-  client.enqueue('type', {})
+  await client.enqueue('type', {})
   t.true(client.flush.calledOnce)
 
-  client.enqueue('type', {})
-  client.enqueue('type', {})
+  await client.enqueue('type', {})
+  await client.enqueue('type', {})
   t.true(client.flush.calledTwice)
 
   await delay(10)


### PR DESCRIPTION
Enqueue's flush now awaits before continuing.

There are cases where race conditions can be given like the examples presented in issue #309. Implementing it asynchronously we make sure that the in-flight flushes ended before continuing.

This problem is also related to the strange behavior that the user has in issue #303 