### PR TITLE
done function updated

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,8 +263,10 @@ class Analytics {
     }
 
     const done = err => {
-      callbacks.forEach(callback => callback(err, data))
-      callback(err, data)
+      setImmediate(() => {
+        callbacks.forEach(callback => callback(err, data))
+        callback(err, data)
+      })
     }
 
     // Don't set the user agent if we're on a browser. The latest spec allows

--- a/test.js
+++ b/test.js
@@ -344,9 +344,11 @@ test('flush - send messages', async t => {
   t.deepEqual(data.batch, ['a', 'b'])
   t.true(data.timestamp instanceof Date)
   t.true(data.sentAt instanceof Date)
-  t.true(callbackA.calledOnce)
-  t.true(callbackB.calledOnce)
-  t.false(callbackC.called)
+  setImmediate(() => {
+    t.true(callbackA.calledOnce)
+    t.true(callbackB.calledOnce)
+    t.false(callbackC.called)
+  })
 })
 
 test('flush - respond with an error', async t => {


### PR DESCRIPTION
This pull request resolves issue #310.

`If a callback function in the messages queue or the callback function passed to flush throws an error, it will trigger the .catch () handler in the axios promise chain and run the thrown error through the error handling code meant for axios errors. This also results in the callback being called twice.`