### PR TITLE
Add an errorHandler property to constructor options

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ class Analytics {
    *   @property {Object} [axiosInstance] (default: axios.create(options.axiosConfig))
    *   @property {Object} [axiosRetryConfig] (optional)
    *   @property {Number} [retryCount] (default: 3)
+   *   @property {Function} [errorHandler] (optional)
    */
 
   constructor (writeKey, options) {
@@ -50,6 +51,7 @@ class Analytics {
     this.maxQueueSize = options.maxQueueSize || 1024 * 450 // 500kb is the API limit, if we approach the limit i.e., 450kb, we'll flush
     this.flushInterval = options.flushInterval || 10000
     this.flushed = false
+    this.errorHandler = options.errorHandler
     Object.defineProperty(this, 'enable', {
       configurable: false,
       writable: false,
@@ -295,6 +297,10 @@ class Analytics {
         return Promise.resolve(data)
       })
       .catch(err => {
+        if (typeof this.errorHandler === 'function') {
+          return this.errorHandler(err)
+        }
+
         if (err.response) {
           const error = new Error(err.response.statusText)
           done(error)

--- a/test.js
+++ b/test.js
@@ -365,6 +365,22 @@ test('flush - respond with an error', async t => {
   await t.throws(client.flush(), 'Bad Request')
 })
 
+test('flush - do not throw on axios failure if errorHandler option is specified', async t => {
+  const errorHandler = spy()
+  const client = createClient({ errorHandler })
+  const callback = spy()
+
+  client.queue = [
+    {
+      message: 'error',
+      callback
+    }
+  ]
+
+  await t.notThrows(client.flush())
+  t.true(errorHandler.calledOnce)
+})
+
 test('flush - time out if configured', async t => {
   const client = createClient({ timeout: 500 })
   const callback = spy()


### PR DESCRIPTION
✔️ All existing tests pass
✔️ New functionality is unit-tested

Addresses #320 #326 

# What this adds

This PR adds an optional `errorHandler` property to the class constructor's options.
If unspecified, the behaviour of the library does not change.
If specified, when an axios request fails, `errorHandler(axiosError)` will be called instead of re-throwing the axios error.

Example usage:

```js
const Analytics = require('analytics-node');

const client = new Analytics('write key', {
  errorHandler: (err) => {
    console.error('analytics-node flush failed.')
    console.error(err)
  }
});

client.track({
  event: 'event name',
  userId: 'user id'
});
// ☝️ if this fails when flushed no exception will be thrown and instead
// the axios error will be logged to the console.

```

# Why

Since no way to handle the re-thrown axios error was exposed previously, this meant that if the axios request failed for any reason, the application using analytics-node would crash. A workaround was to use node's process `unhandledRejection` or `unhandledException` handlers, but this is very un-ergonomic for library users.

# Work remaining

This functionality needs to be documented: https://segment.com/docs/connections/sources/catalog/libraries/server/node/