### PR TITLE
Ensure callback is called when invoking errorHanlder

### DIFF
--- a/index.js
+++ b/index.js
@@ -298,6 +298,7 @@ class Analytics {
       })
       .catch(err => {
         if (typeof this.errorHandler === 'function') {
+          done(err)
           return this.errorHandler(err)
         }
 

--- a/test.js
+++ b/test.js
@@ -381,6 +381,23 @@ test('flush - do not throw on axios failure if errorHandler option is specified'
   t.true(errorHandler.calledOnce)
 })
 
+test('flush - evoke callback when errorHandler option is specified', async t => {
+  const errorHandler = spy()
+  const client = createClient({ errorHandler })
+  const callback = spy()
+
+  client.queue = [
+    {
+      message: 'error',
+      callback
+    }
+  ]
+
+  await t.notThrows(client.flush())
+  await delay(5)
+  t.true(callback.calledOnce)
+})
+
 test('flush - time out if configured', async t => {
   const client = createClient({ timeout: 500 })
   const callback = spy()


### PR DESCRIPTION
I work at Trello @ Atlassian.

We use this library, however, it started causing problems for us when `throw err` was added to the `.flush()` method. This has been documented here. (#320) For us it was resulting in process crashes when we receive an error message (like a 429) when emitting an event. We had to pin the version of this library to a version before this behavior was added.

I saw, that the `errorHandler` property was added (#342) and was attempting to update our code to use it, however, when writing a test case, I saw that my event callback was never invoked when `errorHandler` was present and called 

This is because, in the `.flush()`, everywhere else the method can end, we call `done(err)`, however we do not when looking for and invoking the `errorHandler`. To reiterate the importance, it's a core bit of functionality of this library that the callbacks for events are invoked when the messages are flushed, so it's needs to occur in this instance as well.