### PR TITLE
minimize number of calls to JSON.stringify

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ class Analytics {
     assert(writeKey, 'You must pass your Segment project\'s write key.')
 
     this.queue = []
-    this.queueBytes = 0;
+    this.queueBytes = 0
     this.writeKey = writeKey
     this.host = removeSlash(options.host || 'https://api.segment.io')
     this.path = removeSlash(options.path || '/v1/batch')
@@ -218,14 +218,13 @@ class Analytics {
       return
     }
 
-    
     const hasReachedFlushAt = this.queue.length >= this.flushAt
     if (hasReachedFlushAt) {
       this.flush()
       return
     }
-    
-    this.queueBytes += JSON.stringify(item)
+
+    this.queueBytes += JSON.stringify(message)
     const hasReachedQueueSize = this.queueBytes >= this.maxQueueSize
 
     if (hasReachedQueueSize) {
@@ -263,6 +262,7 @@ class Analytics {
       return Promise.resolve()
     }
 
+    this.queueBytes = 0
     const items = this.queue.splice(0, this.queue.length)
     const callbacks = items.map(item => item.callback)
     const messages = items.map(item => item.message)

--- a/test.js
+++ b/test.js
@@ -318,7 +318,7 @@ test('flush - don\'t fail when queue is empty', async t => {
 })
 
 test('flush - send messages', async t => {
-  const client = createClient({ flushAt: 2 })
+  const client = createClient({ flushAt: 3 })
 
   const callbackA = spy()
   const callbackB = spy()
@@ -341,7 +341,7 @@ test('flush - send messages', async t => {
 
   const data = await client.flush()
   t.deepEqual(Object.keys(data), ['batch', 'timestamp', 'sentAt'])
-  t.deepEqual(data.batch, ['a', 'b'])
+  t.deepEqual(data.batch, ['a', 'b', 'c'])
   t.true(data.timestamp instanceof Date)
   t.true(data.sentAt instanceof Date)
   setImmediate(() => {


### PR DESCRIPTION
Small performance tweak.

Instead of calling `JSON.stringify()` on the entire queue of messages every time we enqueue a message, analytics-node will now keep a running tally of the queue size, and only call `JSON.stringify()` once when the message is enqueued.

This should offer a minor performance-improvement for anybody enqueuing lots of messages.  

---

As an aside, I'm also wondering if this bit of code is actually relevant any more:

```js
    if (!message.messageId) {
      // We md5 the messaage to add more randomness. This is primarily meant
      // for use in the browser where the uuid package falls back to Math.random()
      // which is not a great source of randomness.
      // Borrowed from analytics.js (https://github.com/segment-integrations/analytics.js-integration-segmentio/blob/a20d2a2d222aeb3ab2a8c7e72280f1df2618440e/lib/index.js#L255-L256).
      message.messageId = `node-${md5(JSON.stringify(message))}-${uuid()}`
    }
```

Given that nobody should be running this library in a browser (or on a server without a good source of entropy), can't we just use a plain `uuid()` here?  

I'm afraid to touch this, given that it'd be an actual functionality change, but I think you could probably shave some bytes off of your payloads, and squeeze out a few more CPU cycles if you got rid of the stringify/hashing here!  