### PR TITLE
flush: guarantee that all inflight messages are sent

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,9 +237,13 @@ class Analytics {
    * @return {Analytics}
    */
 
-  async flush (callback) {
-    await this.pendingFlush
-    callback = callback || noop
+  async flush(callback) {
+    {
+      const pending = this.pendingFlush;
+      this.pendingFlush = null;
+      await pending; // this may throw
+    }
+    callback = callback || noop;
 
     if (!this.enable) {
       setImmediate(callback)


### PR DESCRIPTION
Simple fix so flush waits for previous inflight messages to be sent.

Resolves https://github.com/segmentio/analytics-node/issues/309