### PR TITLE
flush: guarantee that all inflight messages are sent 

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ class Analytics {
     this.flushInterval = options.flushInterval || 10000
     this.flushed = false
     this.errorHandler = options.errorHandler
+    this.pendingFlush = null
     Object.defineProperty(this, 'enable', {
       configurable: false,
       writable: false,
@@ -236,7 +237,7 @@ class Analytics {
    * @return {Analytics}
    */
 
-  flush (callback) {
+  async flush (callback) {
     callback = callback || noop
 
     if (!this.enable) {
@@ -252,6 +253,13 @@ class Analytics {
     if (!this.queue.length) {
       setImmediate(callback)
       return Promise.resolve()
+    }
+
+    try {
+      if (this.pendingFlush) { await this.pendingFlush }
+    } catch (err) {
+      this.pendingFlush = null
+      throw err
     }
 
     const items = this.queue.splice(0, this.flushAt)
@@ -291,7 +299,8 @@ class Analytics {
       req.timeout = typeof this.timeout === 'string' ? ms(this.timeout) : this.timeout
     }
 
-    return this.axiosInstance.post(`${this.host}${this.path}`, data, req)
+    return (this.pendingFlush = this.axiosInstance
+      .post(`${this.host}${this.path}`, data, req)
       .then(() => {
         done()
         return Promise.resolve(data)
@@ -310,7 +319,7 @@ class Analytics {
 
         done(err)
         throw err
-      })
+      }))
   }
 
   _isErrorRetryable (error) {


### PR DESCRIPTION
Simple fix so flush waits for previous inflight messages to be sent.

Resolves https://github.com/segmentio/analytics-node/issues/309
